### PR TITLE
Generate ES6 modules (let ember-cli-babel do its thing).

### DIFF
--- a/blueprints/ember-cli-typescript/files/tsconfig.json
+++ b/blueprints/ember-cli-typescript/files/tsconfig.json
@@ -7,6 +7,7 @@
     "noEmit": true,
     "sourceMap": true,
     "baseUrl": ".",
+    "modules": "ES6",
     "paths": {
       "<%= dasherizedPackageName %>/tests/*": ["tests/*"],
       "<%= dasherizedPackageName %>/*": [


### PR DESCRIPTION
This resolves a problem where tools that codemod the imports,
e.g. babel-plugin-ember-modules-api-polyfill, were unable to
work because the modules being generated were not the same ES6
modules as the codemod expected (TS generates CommonJS modules
by default).