### PR TITLE
Use console-ui for TS diagnostics

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,9 @@ module.exports = {
     }
 
     try {
-      registry.add('js', new TsPreprocessor());
+      registry.add('js', new TsPreprocessor({
+        ui: this.ui
+      }));
     } catch (ex) {
       this.ui.write(
         'Missing or invalid tsconfig.json, please fix or run `ember generate ember-cli-typescript`.'

--- a/lib/typescript-preprocessor.js
+++ b/lib/typescript-preprocessor.js
@@ -2,10 +2,9 @@
 const fs = require('fs');
 const path = require('path');
 
-const debug = require('debug')('ember-cli-typescript');
 const funnel = require('broccoli-funnel');
 const mergeTrees = require('broccoli-merge-trees');
-const tsc = require('broccoli-typescript-compiler').typescript;
+const TypeScriptPlugin = require('broccoli-typescript-compiler').TypeScriptPlugin;
 
 const BroccoliDebug = require('broccoli-debug');
 
@@ -16,6 +15,7 @@ class TypeScriptPreprocessor {
     this.name = 'ember-cli-typescript';
     this._tag = tag++;
     this.ext = 'ts';
+    this.ui = options.ui;
 
     // Update the config for how Broccoli handles the file system: no need for
     // includes, always emit, and let Broccoli manage any outDir.
@@ -42,13 +42,16 @@ class TypeScriptPreprocessor {
       `${this._tag}`
     );
 
+    const tsc = new TypeScriptPlugin(uncompiledTs, {
+      throwOnError: this.config.compilerOptions.noEmitOnError,
+      annotation: 'Compiled TS files',
+      include: ['**/*'],
+      tsconfig: this.config,
+    });
+    tsc.setDiagnosticWriter(this.ui.writeWarnLine.bind(this.ui));
+
     const ts = debugTree(
-      tsc(uncompiledTs, {
-        throwOnError: this.config.compilerOptions.noEmitOnError,
-        annotation: 'Compiled TS files',
-        include: ['**/*'],
-        tsconfig: this.config,
-      }),
+      tsc,
       `${this._tag}`
     );
 


### PR DESCRIPTION
Upgrading to e-c-t 1.0 broke our CI setup, because TS warnings were not emitted to stderr (`console.error`) anymore, so went to our JUnit xml file which obviously broke its format, thus the CI server could not parse it anymore. Looks like this was changed in `broccoli-typescript-compiler` on 2.0: https://github.com/tildeio/broccoli-typescript-compiler/commit/379adc05add513a9f56c3a6da7c0086f5b2d4a03#diff-d5edbe17e79bd7d0417b0bac7e92be06L87

Luckily there is an API to change the writer function, so we can use ember-cli's `ui` from ember-cli for all messages. This now also correctly supports the `--silent` flag to suppress any of those messages.