### PR TITLE
Throw SilentError when preprocessor could not be instantiated

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,26 +1,25 @@
 /* eslint-env node */
 
+const fs = require('fs');
+const path = require('path');
 const SilentError = require('silent-error');
+const TsPreprocessor = require('./lib/typescript-preprocessor');
 
-let TsPreprocessor;
-try {
-  TsPreprocessor = require('./lib/typescript-preprocessor');
-} catch (ex) {
-  // Do nothing; we just won't have the plugin available. This means that if you
-  // somehow end up in a state where it doesn't load, the preprocessor *will*
-  // fail, but this is necessary because the preprocessor depends on packages
-  // which aren't installed until the
-}
 
 module.exports = {
   name: 'ember-cli-typescript',
 
   setupPreprocessorRegistry(type, registry) {
-    if (!TsPreprocessor) {
-      this.ui.write(
-        'Note: TypeScript preprocessor not available -- some dependencies not installed. ' +
-          '(If this is during installation of the add-on, this is as expected. If it is ' +
-          'while building, serving, or testing the application, this is an error.)'
+    if (!fs.existsSync(path.join(this.project.root, 'tsconfig.json'))) {
+      // Do nothing; we just won't have the plugin available. This means that if you
+      // somehow end up in a state where it doesn't load, the preprocessor *will*
+      // fail, but this is necessary because the preprocessor depends on packages
+      // which aren't installed until the default blueprint is run
+
+      this.ui.writeInfoLine(
+        'Skipping TypeScript preprocessing as there is no tsconfig.json. ' +
+        '(If this is during installation of the add-on, this is as expected. If it is ' +
+        'while building, serving, or testing the application, this is an error.)'
       );
       return;
     }
@@ -30,7 +29,7 @@ module.exports = {
         ui: this.ui
       }));
     } catch (ex) {
-      throw new SilentError(`Missing or invalid tsconfig.json, please fix or run \`ember generate ember-cli-typescript\`.\n${ex}`);
+      throw new SilentError(`Failed to instantiate TypeScript preprocessor, probably due to an invalid tsconfig.json. Please fix or run \`ember generate ember-cli-typescript\`.\n${ex}`);
     }
   },
 };

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 /* eslint-env node */
 
+const SilentError = require('silent-error');
+
 let TsPreprocessor;
 try {
   TsPreprocessor = require('./lib/typescript-preprocessor');
@@ -28,10 +30,7 @@ module.exports = {
         ui: this.ui
       }));
     } catch (ex) {
-      this.ui.write(
-        'Missing or invalid tsconfig.json, please fix or run `ember generate ember-cli-typescript`.'
-      );
-      this.ui.write('  ' + ex.toString());
+      throw new SilentError(`Missing or invalid tsconfig.json, please fix or run \`ember generate ember-cli-typescript\`.\n${ex}`);
     }
   },
 };

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "broccoli-stew": "^1.4.0",
     "broccoli-typescript-compiler": "^2.0.0",
     "debug": "^2.2.0",
-    "ember-cli-babel": "^6.3.0"
+    "ember-cli-babel": "^6.3.0",
+    "silent-error": "^1.1.0"
   },
   "devDependencies": {
     "@types/ember": "^2.7.43",


### PR DESCRIPTION
To further improve on message handling... I think it is reasonable to cancel the build processes when the TS preprocessor has not been initialized correctly, as the build output without it will certainly be broken. Also this gives a clear error indication (rendered in red color by ember-cli).