### PR TITLE
Solve 'The Mystery of the Missing app.js 🕵️‍♂️'

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const fs = require('fs');
 const path = require('path');
 const SilentError = require('silent-error');
 const TsPreprocessor = require('./lib/typescript-preprocessor');
-const ServeTS = require('./lib/serve-ts');
+const buildServeCommand = require('./lib/serve-ts');
 const funnel = require('broccoli-funnel');
 const mergeTrees = require('broccoli-merge-trees');
 const mkdirp = require('mkdirp');
@@ -28,7 +28,7 @@ module.exports = {
 
   includedCommands() {
     return {
-      'serve-ts': ServeTS,
+      'serve-ts': buildServeCommand(this.project),
     };
   },
 
@@ -71,7 +71,7 @@ module.exports = {
       return mergeTrees([tree, ...additionalTrees]);
     }
 
-    const roots = ['.', ...includes, ...this._inRepoAddons()].map(root => path.join(root, 'app'));
+    const roots = ['.', ...includes, ...this._inRepoAddons()].map(root => path.join(root, 'app/'));
 
     // funnel will fail if the directory doesn't exist
     roots.forEach(root => {
@@ -84,7 +84,7 @@ module.exports = {
         const prefix = roots.find(root => relativePath.startsWith(root));
         if (prefix) {
           // strip any app/ or lib/in-repo-addon/app/ prefix
-          return relativePath.substr(prefix.length + 1);
+          return relativePath.substr(prefix.length);
         }
 
         return relativePath;

--- a/lib/serve-ts.js
+++ b/lib/serve-ts.js
@@ -5,100 +5,100 @@ const child_process = require('child_process');
 const fs = require('fs');
 
 const rimraf = require('rimraf');
-
-const root = process.env.DEVELOPING ? `${process.cwd()}/node_modules/` : '';
-const Serve = require(`${root}ember-cli/lib/commands/serve`);
-const Builder = require(`${root}ember-cli/lib/models/builder`);
-const Watcher = require(`${root}ember-cli/lib/models/watcher`);
-
 const OUT_DIR = '.e-c-ts';
 
-/**
- * Exclude .ts files from being watched
- */
-function filterTS(name) {
-  if (name.startsWith('.')) {
-    // these files are filtered by default
-    return false;
+module.exports = (project) => {
+  const Serve = project.require('ember-cli/lib/commands/serve');
+  const Builder = project.require('ember-cli/lib/models/builder');
+  const Watcher = project.require('ember-cli/lib/models/watcher');
+
+  /**
+   * Exclude .ts files from being watched
+   */
+  function filterTS(name) {
+    if (name.startsWith('.')) {
+      // these files are filtered by default
+      return false;
+    }
+
+    // typescript sources are watched by `tsc --watch` instead
+    return !name.endsWith('.ts');
   }
 
-  // typescript sources are watched by `tsc --watch` instead
-  return !name.endsWith('.ts');
-}
-
-class WatcherNonTS extends Watcher {
-  buildOptions() {
-    let options = super.buildOptions();
-    options.filter = filterTS;
-    return options;
+  class WatcherNonTS extends Watcher {
+    buildOptions() {
+      let options = super.buildOptions();
+      options.filter = filterTS;
+      return options;
+    }
   }
-}
 
-module.exports = Serve.extend({
-  name: 'serve-ts',
-  aliases: ['st'],
-  works: 'insideProject',
-  description:
-    'Serve the app/addon with the TypeScript compiler in incremental mode. (Much faster!)',
+  return Serve.extend({
+    name: 'serve-ts',
+    aliases: ['st'],
+    works: 'insideProject',
+    description:
+      'Serve the app/addon with the TypeScript compiler in incremental mode. (Much faster!)',
 
-  run(options) {
-    this.project._isRunningServeTS = true;
+    run(options) {
+      this.project._isRunningServeTS = true;
 
-    const builder = new Builder({
-      ui: this.ui,
-      outputPath: options.outputPath,
-      project: this.project,
-      environment: options.environment,
-    });
+      const builder = new Builder({
+        ui: this.ui,
+        outputPath: options.outputPath,
+        project: this.project,
+        environment: options.environment,
+      });
 
-    // We're ignoring this because TS doesn't have types for `Watcher`; this is
-    // fine, though.
-    // @ts-ignore
-    const watcher = new WatcherNonTS({
-      ui: this.ui,
-      builder,
-      analytics: this.analytics,
-      options,
-      serving: true,
-    });
+      // We're ignoring this because TS doesn't have types for `Watcher`; this is
+      // fine, though.
+      // @ts-ignore
+      const watcher = new WatcherNonTS({
+        ui: this.ui,
+        builder,
+        analytics: this.analytics,
+        options,
+        serving: true,
+      });
 
-    options._builder = builder;
-    options._watcher = watcher;
+      options._builder = builder;
+      options._watcher = watcher;
 
-    // TODO: typescript might be installed globally?
-    // argument sequence here is meaningful; don't apply prettier.
-    // prettier-ignore
-    this.tsc = child_process.fork(
-      'node_modules/typescript/bin/tsc',
-      [
-        '--watch',
-        '--outDir', OUT_DIR,
-        '--allowJs', 'false',
-        '--noEmit', 'false',
-        '--sourceMap', 'false', // TODO: enable if sourcemaps=true
-      ],
-      {
-        silent: true,
-        execArgv: [],
+      // TODO: typescript might be installed globally?
+      // argument sequence here is meaningful; don't apply prettier.
+      // prettier-ignore
+      this.tsc = child_process.fork(
+        'node_modules/typescript/bin/tsc',
+        [
+          '--watch',
+          '--outDir', OUT_DIR,
+          '--allowJs', 'false',
+          '--noEmit', 'false',
+          '--sourceMap', 'false', // TODO: enable if sourcemaps=true
+        ],
+        {
+          silent: true,
+          execArgv: [],
+        }
+      );
+      this.tsc.stdout.on('data', data => {
+        this.ui.write(data);
+      });
+      this.tsc.stderr.on('data', data => {
+        this.ui.writeError(data);
+      });
+
+      return Serve.prototype.run.call(this, options);
+    },
+
+    onInterrupt() {
+      if (this.tsc) {
+        this.tsc.kill();
       }
-    );
-    this.tsc.stdout.on('data', data => {
-      this.ui.write(data);
-    });
-    this.tsc.stderr.on('data', data => {
-      this.ui.writeError(data);
-    });
 
-    return Serve.prototype.run.call(this, options);
-  },
-
-  onInterrupt() {
-    if (this.tsc) {
-      this.tsc.kill();
-    }
-
-    if (fs.existsSync(OUT_DIR)) {
-      rimraf.sync(OUT_DIR);
-    }
-  },
-});
+      if (fs.existsSync(OUT_DIR)) {
+        rimraf.sync(OUT_DIR);
+      }
+    },
+  });
+};


### PR DESCRIPTION
Incremental compilation was broken because `app.js` was being transformed into a file just called `js`.

This should also fix things when using a linked copy e-c-ts. The `serve-ts` diff is nasty, but all I did was wrap the module in a function so it could use `project.require()` to ensure the CLI imports always resolve to the host app's copy.