### PR TITLE
Assorted improvements

### DIFF
--- a/blueprints/ember-cli-typescript/files/tsconfig.json
+++ b/blueprints/ember-cli-typescript/files/tsconfig.json
@@ -20,11 +20,8 @@ inRepoAddons.forEach(function(path) { %>,
       ]
     }
   },
-  "exclude": [
-    "tmp",
-    "dist",
-    "node_modules",
-    "bower_components",
-    "blueprints"
+  "include": [
+    "app",
+    "tests"
   ]
 }

--- a/blueprints/ember-cli-typescript/index.js
+++ b/blueprints/ember-cli-typescript/index.js
@@ -38,22 +38,6 @@ module.exports = {
   },
 
   afterInstall() {
-    if (existsSync('.gitignore')) {
-      this.insertIntoFile('.gitignore', '\n# Ember CLI TypeScript\n.e-c-ts');
-    }
-
-    if (existsSync('.vscode/settings.json')) {
-      // NOTE: this may or may not actually work -- it assumes that
-      // `"tmp:": true` is in fact set.
-      this.insertIntoFile('.vscode/settings.json', '",\n.e-c-ts": true', {
-        after: '"tmp": true',
-      });
-    }
-
-    // TODO: same for Atom
-    // TODO: same for Sublime
-    // TODO: same for IntelliJ
-
     return this.addPackagesToProject([
       { name: 'typescript', target: 'latest' },
       { name: '@types/ember', target: 'latest' },

--- a/lib/serve-ts.js
+++ b/lib/serve-ts.js
@@ -92,13 +92,15 @@ module.exports = (project) => {
     },
 
     onInterrupt() {
-      if (this.tsc) {
-        this.tsc.kill();
-      }
+      return Serve.prototype.onInterrupt.apply(this, arguments).then(() => {
+        if (this.tsc) {
+          this.tsc.kill();
+        }
 
-      if (fs.existsSync(OUT_DIR)) {
-        rimraf.sync(OUT_DIR);
-      }
+        if (fs.existsSync(OUT_DIR)) {
+          rimraf.sync(OUT_DIR);
+        }
+      });
     },
   });
 };

--- a/lib/serve-ts.js
+++ b/lib/serve-ts.js
@@ -5,9 +5,8 @@ const child_process = require('child_process');
 const fs = require('fs');
 
 const rimraf = require('rimraf');
-const OUT_DIR = '.e-c-ts';
 
-module.exports = (project) => {
+module.exports = (project, outDir) => {
   const Serve = project.require('ember-cli/lib/commands/serve');
   const Builder = project.require('ember-cli/lib/models/builder');
   const Watcher = project.require('ember-cli/lib/models/watcher');
@@ -71,7 +70,7 @@ module.exports = (project) => {
         'node_modules/typescript/bin/tsc',
         [
           '--watch',
-          '--outDir', OUT_DIR,
+          '--outDir', outDir,
           '--allowJs', 'false',
           '--noEmit', 'false',
           '--sourceMap', 'false', // TODO: enable if sourcemaps=true
@@ -97,8 +96,8 @@ module.exports = (project) => {
           this.tsc.kill();
         }
 
-        if (fs.existsSync(OUT_DIR)) {
-          rimraf.sync(OUT_DIR);
+        if (fs.existsSync(outDir)) {
+          rimraf.sync(outDir);
         }
       });
     },

--- a/lib/serve-ts.js
+++ b/lib/serve-ts.js
@@ -40,6 +40,8 @@ module.exports = (project, outDir) => {
       'Serve the app/addon with the TypeScript compiler in incremental mode. (Much faster!)',
 
     run(options) {
+      const config = this.project.config(options.environment);
+
       this.project._isRunningServeTS = true;
 
       return new Promise(resolve => {
@@ -87,6 +89,9 @@ module.exports = (project, outDir) => {
           project: this.project,
           environment: options.environment,
         });
+
+        // This will be populated later by the superclass, but is needed by the Watcher now
+        options.rootURL = config.rootURL || '/';
 
         // We're ignoring this because TS doesn't have types for `Watcher`; this is
         // fine, though.

--- a/lib/serve-ts.js
+++ b/lib/serve-ts.js
@@ -42,52 +42,68 @@ module.exports = (project, outDir) => {
     run(options) {
       this.project._isRunningServeTS = true;
 
-      const builder = new Builder({
-        ui: this.ui,
-        outputPath: options.outputPath,
-        project: this.project,
-        environment: options.environment,
-      });
+      return new Promise(resolve => {
+        let started = false;
 
-      // We're ignoring this because TS doesn't have types for `Watcher`; this is
-      // fine, though.
-      // @ts-ignore
-      const watcher = new WatcherNonTS({
-        ui: this.ui,
-        builder,
-        analytics: this.analytics,
-        options,
-        serving: true,
-      });
+        this.ui.startProgress('Starting TypeScript compilation...');
 
-      options._builder = builder;
-      options._watcher = watcher;
+        // TODO: typescript might be installed globally?
+        // argument sequence here is meaningful; don't apply prettier.
+        // prettier-ignore
+        this.tsc = child_process.fork(
+          'node_modules/typescript/bin/tsc',
+          [
+            '--watch',
+            '--outDir', outDir,
+            '--allowJs', 'false',
+            '--noEmit', 'false',
+            '--sourceMap', 'false', // TODO: enable if sourcemaps=true
+          ],
+          {
+            silent: true,
+            execArgv: [],
+          }
+        );
 
-      // TODO: typescript might be installed globally?
-      // argument sequence here is meaningful; don't apply prettier.
-      // prettier-ignore
-      this.tsc = child_process.fork(
-        'node_modules/typescript/bin/tsc',
-        [
-          '--watch',
-          '--outDir', outDir,
-          '--allowJs', 'false',
-          '--noEmit', 'false',
-          '--sourceMap', 'false', // TODO: enable if sourcemaps=true
-        ],
-        {
-          silent: true,
-          execArgv: [],
-        }
-      );
-      this.tsc.stdout.on('data', data => {
-        this.ui.write(data);
-      });
-      this.tsc.stderr.on('data', data => {
-        this.ui.writeError(data);
-      });
+        this.tsc.stderr.on('data', data => {
+          this.ui.writeError(data);
+        });
 
-      return Serve.prototype.run.call(this, options);
+        this.tsc.stdout.on('data', data => {
+          this.ui.write(data);
+
+          // Wait for the initial compilation to complete before continuing to
+          // minimize thrashing during startup.
+          if (data.indexOf('Compilation complete') !== -1 && !started) {
+            started = true;
+            this.ui.stopProgress();
+            resolve();
+          }
+        });
+      }).then(() => {
+        const builder = new Builder({
+          ui: this.ui,
+          outputPath: options.outputPath,
+          project: this.project,
+          environment: options.environment,
+        });
+
+        // We're ignoring this because TS doesn't have types for `Watcher`; this is
+        // fine, though.
+        // @ts-ignore
+        const watcher = new WatcherNonTS({
+          ui: this.ui,
+          builder,
+          analytics: this.analytics,
+          options,
+          serving: true,
+        });
+
+        options._builder = builder;
+        options._watcher = watcher;
+
+        return Serve.prototype.run.call(this, options);
+      });
     },
 
     onInterrupt() {


### PR DESCRIPTION
Took a little time after lunch to clean up some things I noticed this morning:
 - our `Serve` subclass now calls the superclass's `onInterrupt` so the build shuts down cleanly on ctrl-c
 - the temporary output directory moved to the system tempdir (watching/rebuilds still work just fine locally) to avoid needing to configure exclusions for `.e-c-ts` in the project dir
 - there should be no more thrashing rebuilds between the tsc watcher and the ember-cli watcher:
   - `ember serve-ts` now waits for the initial compilation to complete before building the rest of the app, so the compiled JS is already present in the output directory when the first build runs
   - switching from `exclude` to `include` in the default `tsconfig.json` gets `tsc` to ignore the contents of `tmp` (though this does make things a little more interesting with addons/module unification down the line)
 - the emitted app URL (`Serving on http://localhost:4200/`) should be correct now
