### PR TITLE
Only run Appveyor against one Node/Ember version combo

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,17 +4,11 @@
 init:
   - git config --global core.autocrlf true
 
-# Test against these versions of Node.js.
-environment:
-  matrix:
-    - nodejs_version: "6"
-    - nodejs_version: "7"
-
 # Install scripts. (runs after repo cloning)
 install:
   - git rev-parse HEAD
   # Get the latest stable version of Node 0.STABLE.latest
-  - ps: Install-Product node $env:nodejs_version
+  - ps: Install-Product node 6
   # hide python so node-gyp won't try to build native extentions
   - rename C:\Python27 Python27hidden
   # Typical npm stuff.
@@ -28,7 +22,7 @@ cache:
 test_script:
   # Output useful info for debugging.
   - yarn versions
-  - cmd: yarn run test
+  - cmd: yarn ember test
   - cmd: yarn run nodetest
 
 # Don't actually build.


### PR DESCRIPTION
This simplifies our Appveyor setup not to run ember-try and to only test against one node version. It doesn't seem like ember-try is buying us a ton, since none of the build time components here are impacted by the Ember version, and I think if we want to get a more complete coverage matrix for Node versions, Travis is probably the simpler way to go.