### PR TITLE
Add `util` and `util-test`

### DIFF
--- a/blueprints/test-framework-detector.js
+++ b/blueprints/test-framework-detector.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const VersionChecker = require('ember-cli-version-checker');
+
+module.exports = function(blueprint) {
+  blueprint.supportsAddon = function() {
+    return false;
+  };
+
+  blueprint.filesPath = function() {
+    let type;
+
+    let dependencies = this.project.dependencies();
+    if ('ember-qunit' in dependencies) {
+      type = 'qunit-rfc-232';
+
+    } else if ('ember-cli-qunit' in dependencies) {
+      let checker = new VersionChecker(this.project);
+      if (fs.existsSync(this.path + '/qunit-rfc-232-files') && checker.for('ember-cli-qunit', 'npm').gte('4.2.0')) {
+        type = 'qunit-rfc-232';
+      } else {
+        type = 'qunit';
+      }
+
+    } else if ('ember-mocha' in dependencies) {
+      type = 'mocha-0.12';
+
+    } else if ('ember-cli-mocha' in dependencies) {
+      let checker = new VersionChecker(this.project);
+      if (fs.existsSync(this.path + '/mocha-0.12-files') && checker.for('ember-cli-mocha', 'npm').gte('0.12.0')) {
+        type = 'mocha-0.12';
+      } else {
+        type = 'mocha';
+      }
+
+    } else {
+      this.ui.writeLine('Couldn\'t determine test style - using QUnit');
+      type = 'qunit';
+    }
+
+    return path.join(this.path, type + '-files');
+  };
+
+  return blueprint;
+};

--- a/blueprints/util-test/index.js
+++ b/blueprints/util-test/index.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const stringUtils = require('ember-cli-string-utils');
+
+const useTestFrameworkDetector = require('../test-framework-detector');
+
+module.exports = useTestFrameworkDetector({
+  description: 'Generates a util unit test.',
+  locals: function(options) {
+    return {
+      friendlyTestName: ['Unit', 'Utility', options.entity.name].join(' | '),
+      dasherizedModulePrefix: stringUtils.dasherize(options.project.config().modulePrefix)
+    };
+  }
+});

--- a/blueprints/util-test/mocha-files/tests/unit/utils/__name__-test.ts
+++ b/blueprints/util-test/mocha-files/tests/unit/utils/__name__-test.ts
@@ -1,0 +1,11 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import <%= camelizedModuleName %> from '<%= dasherizedPackageName %>/utils/<%= dasherizedModuleName %>';
+
+describe('<%= friendlyTestName %>', function() {
+  // Replace this with your real tests.
+  it('works', function() {
+    let result = <%= camelizedModuleName %>();
+    expect(result).to.be.ok;
+  });
+});

--- a/blueprints/util-test/qunit-files/tests/unit/utils/__name__-test.ts
+++ b/blueprints/util-test/qunit-files/tests/unit/utils/__name__-test.ts
@@ -1,0 +1,10 @@
+import <%= camelizedModuleName %> from '<%= dasherizedModulePrefix %>/utils/<%= dasherizedModuleName %>';
+import { module, test } from 'qunit';
+
+module('<%= friendlyTestName %>');
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  let result = <%= camelizedModuleName %>();
+  assert.ok(result);
+});

--- a/blueprints/util-test/qunit-rfc-232-files/tests/unit/utils/__name__-test.ts
+++ b/blueprints/util-test/qunit-rfc-232-files/tests/unit/utils/__name__-test.ts
@@ -1,0 +1,11 @@
+import <%= camelizedModuleName %> from '<%= dasherizedModulePrefix %>/utils/<%= dasherizedModuleName %>';
+import { module, test } from 'qunit';
+
+module('<%= friendlyTestName %>', function(hooks) {
+
+  // Replace this with your real tests.
+  test('it works', function(assert) {
+    let result = <%= camelizedModuleName %>();
+    assert.ok(result);
+  });
+});

--- a/blueprints/util/files/__root__/utils/__name__.ts
+++ b/blueprints/util/files/__root__/utils/__name__.ts
@@ -1,0 +1,3 @@
+export default function <%= camelizedModuleName %>() {
+  return true;
+}

--- a/blueprints/util/index.js
+++ b/blueprints/util/index.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  description: 'Generates a simple utility module/function.'
+};

--- a/node-tests/blueprints/util-test-test.js
+++ b/node-tests/blueprints/util-test-test.js
@@ -1,0 +1,84 @@
+'use strict';
+
+const blueprintHelpers = require('ember-cli-blueprint-test-helpers/helpers');
+const setupTestHooks = blueprintHelpers.setupTestHooks;
+const emberNew = blueprintHelpers.emberNew;
+const emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
+const modifyPackages = blueprintHelpers.modifyPackages;
+
+const chai = require('ember-cli-blueprint-test-helpers/chai');
+const expect = chai.expect;
+
+const generateFakePackageManifest = require('../helpers/generate-fake-package-manifest');
+const fixture = require('../helpers/fixture');
+
+describe('Blueprint: util-test', function() {
+  setupTestHooks(this);
+
+  describe('in app', function() {
+    beforeEach(function() {
+      return emberNew();
+    });
+
+    describe('with ember-cli-qunit before v4.2.0', function() {
+      beforeEach(function() {
+        generateFakePackageManifest('ember-cli-qunit', '4.1.1');
+      });
+
+      it('util-test foo-bar', function() {
+        return emberGenerateDestroy(['util-test', 'foo-bar'], _file => {
+          expect(_file('tests/unit/utils/foo-bar-test.ts'))
+            .to.equal(fixture('util-test/default.ts'));
+        });
+      });
+    });
+
+    describe('with ember-cli-qunit@4.2.0', function() {
+      beforeEach(function() {
+        generateFakePackageManifest('ember-cli-qunit', '4.2.0');
+      });
+
+      it('util-test foo-bar', function() {
+        return emberGenerateDestroy(['util-test', 'foo-bar'], _file => {
+          expect(_file('tests/unit/utils/foo-bar-test.ts'))
+            .to.equal(fixture('util-test/rfc232.ts'));
+        });
+      });
+    });
+
+    describe('with ember-cli-mocha', function() {
+      beforeEach(function() {
+        modifyPackages([
+          { name: 'ember-cli-qunit', delete: true },
+          { name: 'ember-cli-mocha', dev: true }
+        ]);
+      });
+
+      it('util-test foo-bar', function() {
+        return emberGenerateDestroy(['util-test', 'foo-bar'], _file => {
+          expect(_file('tests/unit/utils/foo-bar-test.ts'))
+            .to.equal(fixture('util-test/mocha.ts'));
+        });
+      });
+    });
+  });
+
+  describe('in addon', function() {
+    beforeEach(function() {
+      return emberNew({ target: 'addon' });
+    });
+
+    describe('with ember-cli-qunit before v4.2.0', function() {
+      beforeEach(function() {
+        generateFakePackageManifest('ember-cli-qunit', '4.1.1');
+      });
+
+      it('util-test foo-bar', function() {
+        return emberGenerateDestroy(['util-test', 'foo-bar'], _file => {
+          expect(_file('tests/unit/utils/foo-bar-test.ts'))
+            .to.equal(fixture('util-test/dummy.ts'));
+        });
+      });
+    });
+  });
+});

--- a/node-tests/blueprints/util-test.js
+++ b/node-tests/blueprints/util-test.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const blueprintHelpers = require('ember-cli-blueprint-test-helpers/helpers');
+const setupTestHooks = blueprintHelpers.setupTestHooks;
+const emberNew = blueprintHelpers.emberNew;
+const emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
+
+const expect = require('ember-cli-blueprint-test-helpers/chai').expect;
+
+describe('Acceptance: ember generate and destroy util', function() {
+  setupTestHooks(this);
+
+  it('util foo', function() {
+    let args = ['util', 'foo-bar'];
+
+    // pass any additional command line options in the arguments array
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, (file) => {
+        expect(file('app/utils/foo-bar.ts')).to.contain('export default function fooBar');
+    }));
+  });
+});

--- a/node-tests/fixtures/util-test/.eslintrc.js
+++ b/node-tests/fixtures/util-test/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  rules: {
+    'no-unused-vars': 'off'
+  }
+}

--- a/node-tests/fixtures/util-test/default.ts
+++ b/node-tests/fixtures/util-test/default.ts
@@ -1,0 +1,10 @@
+import fooBar from 'my-app/utils/foo-bar';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | foo-bar');
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  let result = fooBar();
+  assert.ok(result);
+});

--- a/node-tests/fixtures/util-test/dummy.ts
+++ b/node-tests/fixtures/util-test/dummy.ts
@@ -1,0 +1,10 @@
+import fooBar from 'dummy/utils/foo-bar';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | foo-bar');
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  let result = fooBar();
+  assert.ok(result);
+});

--- a/node-tests/fixtures/util-test/mocha.ts
+++ b/node-tests/fixtures/util-test/mocha.ts
@@ -1,0 +1,11 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import fooBar from 'my-app/utils/foo-bar';
+
+describe('Unit | Utility | foo-bar', function() {
+  // Replace this with your real tests.
+  it('works', function() {
+    let result = fooBar();
+    expect(result).to.be.ok;
+  });
+});

--- a/node-tests/fixtures/util-test/rfc232.ts
+++ b/node-tests/fixtures/util-test/rfc232.ts
@@ -1,0 +1,11 @@
+import fooBar from 'my-app/utils/foo-bar';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | foo-bar', function(hooks) {
+
+  // Replace this with your real tests.
+  test('it works', function(assert) {
+    let result = fooBar();
+    assert.ok(result);
+  });
+});

--- a/node-tests/helpers/fixture.js
+++ b/node-tests/helpers/fixture.js
@@ -1,0 +1,8 @@
+'use strict';
+
+const path = require('path');
+const file = require('ember-cli-blueprint-test-helpers/chai').file;
+
+module.exports = function(filePath) {
+  return file(path.join(__dirname, '../fixtures', filePath));
+};

--- a/node-tests/helpers/generate-fake-package-manifest.js
+++ b/node-tests/helpers/generate-fake-package-manifest.js
@@ -1,0 +1,13 @@
+var fs = require('fs');
+
+module.exports = function generateFakePackageManifest(name, version) {
+  if (!fs.existsSync('node_modules')) {
+    fs.mkdirSync('node_modules');
+  }
+  if (!fs.existsSync('node_modules/' + name)) {
+    fs.mkdirSync('node_modules/' + name);
+  }
+  fs.writeFileSync('node_modules/' + name + '/package.json', JSON.stringify({
+    version: version,
+  }));
+};


### PR DESCRIPTION
There are a couple of things different about this one.

1. I figured that it would reduce noise and clutter to start grouping similar generators together. So, I included both `util` and `util-test`. The generator for `util` was straightforward, just like the others. However ...
2. I got the error `Cannot find module '../test-framework-generator'` in `util-test-test.js`. I'm assuming this is because, in a real Ember app, the CLI is looking at what test framework you have installed and selecting the test file that way. I was hoping there would be another command line argument to specify test framework, but it doesn't look like there is. Any ideas on how to test? For the time being, I just left out tests for `util-test`.