### PR TITLE
Add `helper` related generators

### DIFF
--- a/blueprints/-addon-import.js
+++ b/blueprints/-addon-import.js
@@ -1,0 +1,54 @@
+'use strict';
+
+var stringUtil  = require('ember-cli-string-utils');
+var path        = require('path');
+var inflector   = require('inflection');
+
+module.exports = {
+  description: 'Generates an import wrapper.',
+
+  fileMapTokens: function() {
+    return {
+      __name__: function(options) {
+        if (options.pod && options.hasPathToken) {
+          return options.locals.blueprintName;
+        }
+        return options.dasherizedModuleName;
+      },
+      __path__: function(options) {
+        if (options.pod && options.hasPathToken) {
+          return path.join(options.podPath, options.dasherizedModuleName);
+        }
+        return inflector.pluralize(options.locals.blueprintName);
+      },
+      __root__: function(options) {
+        if (options.inRepoAddon) {
+          return path.join('lib', options.inRepoAddon, 'app');
+        }
+        return 'app';
+      }
+    };
+  },
+
+  locals: function(options) {
+    var addonRawName       = options.inRepoAddon ? options.inRepoAddon : options.project.name();
+    var addonName          = stringUtil.dasherize(addonRawName);
+    var fileName           = stringUtil.dasherize(options.entity.name);
+    var blueprintName      = options.originBlueprintName;
+    var modulePathSegments = [addonName, inflector.pluralize(options.originBlueprintName), fileName];
+
+    if (blueprintName.match(/-addon/)) {
+      blueprintName = blueprintName.substr(0, blueprintName.indexOf('-addon'));
+      modulePathSegments = [addonName, inflector.pluralize(blueprintName), fileName];
+    }
+
+    if (options.pod) {
+      modulePathSegments = [addonName, fileName, blueprintName];
+    }
+
+    return {
+      modulePath: modulePathSegments.join('/'),
+      blueprintName: blueprintName
+    };
+  }
+};

--- a/blueprints/helper-addon/files/__root__/__path__/__name__.ts
+++ b/blueprints/helper-addon/files/__root__/__path__/__name__.ts
@@ -1,0 +1,1 @@
+export { default, <%= camelizedModuleName %> } from '<%= modulePath %>';

--- a/blueprints/helper-addon/index.js
+++ b/blueprints/helper-addon/index.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('../-addon-import');

--- a/blueprints/helper-test/index.js
+++ b/blueprints/helper-test/index.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const stringUtils = require('ember-cli-string-utils');
+const isPackageMissing = require('ember-cli-is-package-missing');
+
+const useTestFrameworkDetector = require('../test-framework-detector');
+
+module.exports = useTestFrameworkDetector({
+  description: 'Generates a helper integration test or a unit test.',
+
+  availableOptions: [
+    {
+      name: 'test-type',
+      type: ['integration', 'unit'],
+      default: 'integration',
+      aliases: [
+        { 'i': 'integration' },
+        { 'u': 'unit' },
+        { 'integration': 'integration' },
+        { 'unit': 'unit' }
+      ]
+    }
+  ],
+
+  fileMapTokens: function() {
+    return {
+      __testType__: function(options) {
+        return options.locals.testType || 'integration';
+      }
+    };
+  },
+
+  locals: function(options) {
+    let testType = options.testType || 'integration';
+    let testName = testType === 'integration' ? 'Integration' : 'Unit';
+    let friendlyTestName = [testName, 'Helper', options.entity.name].join(' | ');
+
+    return {
+      friendlyTestName: friendlyTestName,
+      dasherizedModulePrefix: stringUtils.dasherize(options.project.config().modulePrefix),
+      testType: testType
+    };
+  },
+
+  afterInstall: function(options) {
+    if (!options.dryRun && options.testType === 'integration' && isPackageMissing(this, 'ember-cli-htmlbars-inline-precompile')) {
+      return this.addPackagesToProject([
+        { name: 'ember-cli-htmlbars-inline-precompile', target: '^0.3.1' }
+      ]);
+    }
+  }
+});

--- a/blueprints/helper-test/mocha-0.12-files/tests/__testType__/helpers/__name__-test.ts
+++ b/blueprints/helper-test/mocha-0.12-files/tests/__testType__/helpers/__name__-test.ts
@@ -1,0 +1,38 @@
+import { expect } from 'chai';
+<% if (testType == 'integration') { %>import { describe, it } from 'mocha';
+import { setupComponentTest } from 'ember-mocha';
+import hbs from 'htmlbars-inline-precompile';
+
+describe('<%= friendlyTestName %>', function() {
+  setupComponentTest('<%= dasherizedModuleName %>', {
+    integration: true
+  });
+
+  it('renders', function() {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.on('myAction', function(val) { ... });
+    // Template block usage:
+    // this.render(hbs`
+    //   {{#<%= dasherizedModuleName %>}}
+    //     template content
+    //   {{/<%= dasherizedModuleName %>}}
+    // `);
+    this.set('inputValue', '1234');
+
+    this.render(hbs`{{<%= dasherizedModuleName %> inputValue}}`);
+
+    expect(this.$().text().trim()).to.equal('1234');
+  });
+});
+<% } else if (testType == 'unit') { %>import { describe, it } from 'mocha';
+import { <%= camelizedModuleName %> } from '<%= dasherizedPackageName %>/helpers/<%= dasherizedModuleName %>';
+
+describe('<%= friendlyTestName %>', function() {
+
+  // Replace this with your real tests.
+  it('works', function() {
+    let result = <%= camelizedModuleName %>(42);
+    expect(result).to.be.ok;
+  });
+});
+<% } %>

--- a/blueprints/helper-test/mocha-files/tests/__testType__/helpers/__name__-test.ts
+++ b/blueprints/helper-test/mocha-files/tests/__testType__/helpers/__name__-test.ts
@@ -1,0 +1,39 @@
+import { expect } from 'chai';
+<% if (testType == 'integration') { %>
+import { describeComponent, it } from 'ember-mocha';
+import hbs from 'htmlbars-inline-precompile';
+
+describeComponent('<%= dasherizedModuleName %>', 'helper:<%= dasherizedModuleName %>',
+  {
+    integration: true
+  },
+  function() {
+    it('renders', function() {
+      // Set any properties with this.set('myProperty', 'value');
+      // Handle any actions with this.on('myAction', function(val) { ... });
+      // Template block usage:
+      // this.render(hbs`
+      //   {{#<%= dasherizedModuleName %>}}
+      //     template content
+      //   {{/<%= dasherizedModuleName %>}}
+      // `);
+      this.set('inputValue', '1234');
+
+      this.render(hbs`{{<%= dasherizedModuleName %> inputValue}}`);
+
+      expect(this.$().text().trim()).to.equal('1234');
+    });
+  }
+);
+<% } else if (testType == 'unit') { %>import { describe, it } from 'mocha';
+import { <%= camelizedModuleName %> } from '<%= dasherizedPackageName %>/helpers/<%= dasherizedModuleName %>';
+
+describe('<%= friendlyTestName %>', function() {
+
+  // Replace this with your real tests.
+  it('works', function() {
+    let result = <%= camelizedModuleName %>(42);
+    expect(result).to.be.ok;
+  });
+});
+<% } %>

--- a/blueprints/helper-test/qunit-files/tests/__testType__/helpers/__name__-test.ts
+++ b/blueprints/helper-test/qunit-files/tests/__testType__/helpers/__name__-test.ts
@@ -1,0 +1,26 @@
+<% if (testType == 'integration') { %>import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('<%= dasherizedModuleName %>', 'helper:<%= dasherizedModuleName %>', {
+  integration: true
+});
+
+// Replace this with your real tests.
+test('it renders', function(assert) {
+  this.set('inputValue', '1234');
+
+  this.render(hbs`{{<%= dasherizedModuleName %> inputValue}}`);
+
+  assert.equal(this.$().text().trim(), '1234');
+});<% } else if (testType == 'unit') { %>
+import { <%= camelizedModuleName %> } from '<%= dasherizedModulePrefix %>/helpers/<%= dasherizedModuleName %>';
+import { module, test } from 'qunit';
+
+module('<%= friendlyTestName %>');
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  let result = <%= camelizedModuleName %>([42]);
+  assert.ok(result);
+});
+<% } %>

--- a/blueprints/helper-test/qunit-rfc-232-files/tests/__testType__/helpers/__name__-test.ts
+++ b/blueprints/helper-test/qunit-rfc-232-files/tests/__testType__/helpers/__name__-test.ts
@@ -1,0 +1,29 @@
+<% if (testType === 'integration') { %>import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('<%= friendlyTestName %>', function(hooks) {
+  setupRenderingTest(hooks);
+
+  // Replace this with your real tests.
+  test('it renders', async function(assert) {
+    this.set('inputValue', '1234');
+
+    await render(hbs`{{<%= dasherizedModuleName %> inputValue}}`);
+
+    assert.equal(this.element.textContent.trim(), '1234');
+  });
+});<% } else if (testType === 'unit') { %>import { <%= camelizedModuleName %> } from '<%= dasherizedModulePrefix %>/helpers/<%= dasherizedModuleName %>';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('<%= friendlyTestName %>', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it works', function(assert) {
+    let result = <%= camelizedModuleName %>([42]);
+    assert.ok(result);
+  });
+});<% } %>

--- a/node-tests/blueprints/helper-addon-test.js
+++ b/node-tests/blueprints/helper-addon-test.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const blueprintHelpers = require('ember-cli-blueprint-test-helpers/helpers');
+const setupTestHooks = blueprintHelpers.setupTestHooks;
+const emberNew = blueprintHelpers.emberNew;
+const emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
+
+const chai = require('ember-cli-blueprint-test-helpers/chai');
+const expect = chai.expect;
+
+const fixture = require('../helpers/fixture');
+
+describe('Blueprint: helper-addon', function() {
+  setupTestHooks(this);
+
+  describe('in addon', function() {
+    beforeEach(function() {
+      return emberNew({ target: 'addon' });
+    });
+
+    it('helper-addon foo/bar-baz', function() {
+      return emberGenerateDestroy(['helper-addon', 'foo/bar-baz'], _file => {
+        expect(_file('app/helpers/foo/bar-baz.ts'))
+          .to.equal(fixture('helper-addon.ts'));
+      });
+    });
+  });
+});

--- a/node-tests/blueprints/helper-test-test.js
+++ b/node-tests/blueprints/helper-test-test.js
@@ -1,0 +1,130 @@
+'use strict';
+
+const blueprintHelpers = require('ember-cli-blueprint-test-helpers/helpers');
+const setupTestHooks = blueprintHelpers.setupTestHooks;
+const emberNew = blueprintHelpers.emberNew;
+const emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
+const modifyPackages = blueprintHelpers.modifyPackages;
+
+const chai = require('ember-cli-blueprint-test-helpers/chai');
+const expect = chai.expect;
+
+const generateFakePackageManifest = require('../helpers/generate-fake-package-manifest');
+const fixture = require('../helpers/fixture');
+
+describe('Blueprint: helper-test', function() {
+  setupTestHooks(this);
+
+  describe('in app', function() {
+    beforeEach(function() {
+      return emberNew();
+    });
+
+    describe('with ember-cli-qunit<4.2.0', function() {
+      beforeEach(function() {
+        generateFakePackageManifest('ember-cli-qunit', '4.1.1');
+      });
+
+      it('helper-test foo/bar-baz', function() {
+        return emberGenerateDestroy(['helper-test', 'foo/bar-baz'], _file => {
+          expect(_file('tests/integration/helpers/foo/bar-baz-test.ts'))
+            .to.equal(fixture('helper-test/integration.ts'));
+        });
+      });
+
+      it('helper-test foo/bar-baz --integration', function() {
+        return emberGenerateDestroy(['helper-test', 'foo/bar-baz', '--integration'], _file => {
+          expect(_file('tests/integration/helpers/foo/bar-baz-test.ts'))
+            .to.equal(fixture('helper-test/integration.ts'));
+        });
+      });
+    });
+
+    describe('with ember-cli-qunit@4.2.0', function() {
+      beforeEach(function() {
+        generateFakePackageManifest('ember-cli-qunit', '4.2.0');
+      });
+
+      it('helper-test foo/bar-baz', function() {
+        return emberGenerateDestroy(['helper-test', 'foo/bar-baz'], _file => {
+          expect(_file('tests/integration/helpers/foo/bar-baz-test.ts'))
+            .to.equal(fixture('helper-test/rfc232.ts'));
+        });
+      });
+
+      it('helper-test foo/bar-baz --unit', function() {
+        return emberGenerateDestroy(['helper-test', 'foo/bar-baz', '--unit'], _file => {
+          expect(_file('tests/unit/helpers/foo/bar-baz-test.ts'))
+            .to.equal(fixture('helper-test/rfc232-unit.ts'));
+        });
+      });
+    });
+
+    describe('with ember-cli-mocha@0.11.0', function() {
+      beforeEach(function() {
+        modifyPackages([
+          { name: 'ember-cli-qunit', delete: true },
+          { name: 'ember-cli-mocha', dev: true }
+        ]);
+        generateFakePackageManifest('ember-cli-mocha', '0.11.0');
+      });
+
+      it('helper-test foo/bar-baz --integration', function() {
+        return emberGenerateDestroy(['helper-test', 'foo/bar-baz'], _file => {
+          expect(_file('tests/integration/helpers/foo/bar-baz-test.ts'))
+            .to.equal(fixture('helper-test/mocha.ts'));
+        });
+      });
+
+      it('helper-test foo/bar-baz --unit', function() {
+        return emberGenerateDestroy(['helper-test', 'foo/bar-baz', '--unit'], _file => {
+          expect(_file('tests/unit/helpers/foo/bar-baz-test.ts'))
+            .to.equal(fixture('helper-test/mocha-unit.ts'));
+        });
+      });
+    });
+
+    describe('with ember-cli-mocha@0.12.0', function() {
+      beforeEach(function() {
+        modifyPackages([
+          { name: 'ember-cli-qunit', delete: true },
+          { name: 'ember-cli-mocha', dev: true }
+        ]);
+        generateFakePackageManifest('ember-cli-mocha', '0.12.0');
+      });
+
+      it('helper-test foo/bar-baz for mocha', function() {
+        return emberGenerateDestroy(['helper-test', 'foo/bar-baz'], _file => {
+          expect(_file('tests/integration/helpers/foo/bar-baz-test.ts'))
+            .to.equal(fixture('helper-test/mocha-0.12.ts'));
+        });
+      });
+
+      it('helper-test foo/bar-baz for mocha --unit', function() {
+        return emberGenerateDestroy(['helper-test', 'foo/bar-baz', '--unit'], _file => {
+          expect(_file('tests/unit/helpers/foo/bar-baz-test.ts'))
+            .to.equal(fixture('helper-test/mocha-0.12-unit.ts'));
+        });
+      });
+    });
+  });
+
+  describe('in addon', function() {
+    beforeEach(function() {
+      return emberNew({ target: 'addon' });
+    });
+
+    describe('with ember-cli-qunit<4.2.0', function() {
+      beforeEach(function() {
+        generateFakePackageManifest('ember-cli-qunit', '4.1.1');
+      });
+
+      it('helper-test foo/bar-baz', function() {
+        return emberGenerateDestroy(['helper-test', 'foo/bar-baz'], _file => {
+          expect(_file('tests/integration/helpers/foo/bar-baz-test.ts'))
+            .to.equal(fixture('helper-test/integration.ts'));
+        });
+      });
+    });
+  });
+});

--- a/node-tests/fixtures/helper-addon.ts
+++ b/node-tests/fixtures/helper-addon.ts
@@ -1,0 +1,1 @@
+export { default, fooBarBaz } from 'my-addon/helpers/foo/bar-baz';

--- a/node-tests/fixtures/helper-test/integration.ts
+++ b/node-tests/fixtures/helper-test/integration.ts
@@ -1,0 +1,15 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('foo/bar-baz', 'helper:foo/bar-baz', {
+  integration: true
+});
+
+// Replace this with your real tests.
+test('it renders', function(assert) {
+  this.set('inputValue', '1234');
+
+  this.render(hbs`{{foo/bar-baz inputValue}}`);
+
+  assert.equal(this.$().text().trim(), '1234');
+});

--- a/node-tests/fixtures/helper-test/mocha-0.12-unit.ts
+++ b/node-tests/fixtures/helper-test/mocha-0.12-unit.ts
@@ -1,0 +1,13 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { fooBarBaz } from 'my-app/helpers/foo/bar-baz';
+
+describe('Unit | Helper | foo/bar-baz', function() {
+
+  // Replace this with your real tests.
+  it('works', function() {
+    let result = fooBarBaz(42);
+    expect(result).to.be.ok;
+  });
+});
+

--- a/node-tests/fixtures/helper-test/mocha-0.12.ts
+++ b/node-tests/fixtures/helper-test/mocha-0.12.ts
@@ -1,0 +1,27 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupComponentTest } from 'ember-mocha';
+import hbs from 'htmlbars-inline-precompile';
+
+describe('Integration | Helper | foo/bar-baz', function() {
+  setupComponentTest('foo/bar-baz', {
+    integration: true
+  });
+
+  it('renders', function() {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.on('myAction', function(val) { ... });
+    // Template block usage:
+    // this.render(hbs`
+    //   {{#foo/bar-baz}}
+    //     template content
+    //   {{/foo/bar-baz}}
+    // `);
+    this.set('inputValue', '1234');
+
+    this.render(hbs`{{foo/bar-baz inputValue}}`);
+
+    expect(this.$().text().trim()).to.equal('1234');
+  });
+});
+

--- a/node-tests/fixtures/helper-test/mocha-unit.ts
+++ b/node-tests/fixtures/helper-test/mocha-unit.ts
@@ -1,0 +1,13 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { fooBarBaz } from 'my-app/helpers/foo/bar-baz';
+
+describe('Unit | Helper | foo/bar-baz', function() {
+
+  // Replace this with your real tests.
+  it('works', function() {
+    let result = fooBarBaz(42);
+    expect(result).to.be.ok;
+  });
+});
+

--- a/node-tests/fixtures/helper-test/mocha.ts
+++ b/node-tests/fixtures/helper-test/mocha.ts
@@ -1,0 +1,28 @@
+import { expect } from 'chai';
+
+import { describeComponent, it } from 'ember-mocha';
+import hbs from 'htmlbars-inline-precompile';
+
+describeComponent('foo/bar-baz', 'helper:foo/bar-baz',
+  {
+    integration: true
+  },
+  function() {
+    it('renders', function() {
+      // Set any properties with this.set('myProperty', 'value');
+      // Handle any actions with this.on('myAction', function(val) { ... });
+      // Template block usage:
+      // this.render(hbs`
+      //   {{#foo/bar-baz}}
+      //     template content
+      //   {{/foo/bar-baz}}
+      // `);
+      this.set('inputValue', '1234');
+
+      this.render(hbs`{{foo/bar-baz inputValue}}`);
+
+      expect(this.$().text().trim()).to.equal('1234');
+    });
+  }
+);
+

--- a/node-tests/fixtures/helper-test/rfc232-unit.ts
+++ b/node-tests/fixtures/helper-test/rfc232-unit.ts
@@ -1,0 +1,13 @@
+import { fooBarBaz } from 'my-app/helpers/foo/bar-baz';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Helper | foo/bar-baz', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it works', function(assert) {
+    let result = fooBarBaz([42]);
+    assert.ok(result);
+  });
+});

--- a/node-tests/fixtures/helper-test/rfc232.ts
+++ b/node-tests/fixtures/helper-test/rfc232.ts
@@ -1,0 +1,17 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Helper | foo/bar-baz', function(hooks) {
+  setupRenderingTest(hooks);
+
+  // Replace this with your real tests.
+  test('it renders', async function(assert) {
+    this.set('inputValue', '1234');
+
+    await render(hbs`{{foo/bar-baz inputValue}}`);
+
+    assert.equal(this.element.textContent.trim(), '1234');
+  });
+});

--- a/node-tests/fixtures/helper-test/unit.ts
+++ b/node-tests/fixtures/helper-test/unit.ts
@@ -1,0 +1,12 @@
+
+import { fooBarBaz } from 'my-app/helpers/foo/bar-baz';
+import { module, test } from 'qunit';
+
+module('Unit | Helper | foo/bar-baz');
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  let result = fooBarBaz([42]);
+  assert.ok(result);
+});
+


### PR DESCRIPTION
This was my first go at a `*-addon` generator. Like `*-test`, it also required copying some files from the `ember.js` repo.