### PR TITLE
require dep on ember-cli-version-checker 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "ember-cli-string-utils": "^1.1.0",
     "ember-cli-test-info": "^1.0.0",
     "ember-cli-valid-component-name": "^1.0.0",
+    "ember-cli-version-checker": "^2.1.0",
     "ember-router-generator": "^1.2.3",
     "execa": "^0.9.0",
     "exists-sync": "^0.0.4",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "ember-cli-string-utils": "^1.1.0",
     "ember-cli-test-info": "^1.0.0",
     "ember-cli-valid-component-name": "^1.0.0",
-    "ember-cli-version-checker": "^2.1.0",
     "ember-router-generator": "^1.2.3",
     "execa": "^0.9.0",
     "exists-sync": "^0.0.4",
@@ -90,6 +89,7 @@
     "typescript": "^2.7.1"
   },
   "peerDependencies": {
+    "ember-cli-version-checker": "^2.1.0",
     "typescript": "^2.4.2"
   },
   "engines": {


### PR DESCRIPTION
`blueprints/test-framework-detector.js` requires `ember-cli-version-checker`, but package.json doesn't specify a version. I don't think any ember app/addon is likely to be missing this dependency, since `ember-cli-babel` uses it, but this does mean that the version a developer has when they run the blueprint is likely to float.

This bit me because I encountered a bug when running e-c-ts generators in a private scoped addon. The bug is fixed in ember-cli-version-checker 2.1.0, so specifying the version in e-c-ts ensures that that bugfix is available for generators.