### PR TITLE
Fix default generated types.

### DIFF
--- a/blueprints/ember-cli-typescript/index.js
+++ b/blueprints/ember-cli-typescript/index.js
@@ -4,10 +4,14 @@ const fs = require('fs');
 const path = require('path');
 
 const APP_DECLARATIONS = `
+import Ember from 'ember';
+
 declare global {
   interface Array<T> extends Ember.ArrayPrototypeExtensions<T> {}
   // interface Function extends Ember.FunctionPrototypeExtensions {}
 }
+
+export {};
 `;
 
 module.exports = {


### PR DESCRIPTION
- We need to include an `export` so that ambient type declarations work.
- We need to actually import Ember so that the prototype extensions work.

Thanks to @gossi for the report!