### PR TITLE
Fix node-tests

### DIFF
--- a/node-tests/blueprints/acceptance-test-test.js
+++ b/node-tests/blueprints/acceptance-test-test.js
@@ -17,7 +17,7 @@ describe('Blueprint: acceptance-test', function() {
 
   describe('in app', function() {
     beforeEach(function() {
-      return emberNew();
+      return emberNew().then(() => generateFakePackageManifest('ember-cli-qunit', '4.1.0'));
     });
 
     it('acceptance-test foo', function() {
@@ -62,7 +62,9 @@ describe('Blueprint: acceptance-test', function() {
 
   describe('in addon', function() {
     beforeEach(function() {
-      return emberNew({ target: 'addon' });
+      return emberNew({ target: 'addon' }).then(() =>
+        generateFakePackageManifest('ember-cli-qunit', '4.1.0')
+      );
     });
 
     it('acceptance-test foo', function() {

--- a/node-tests/blueprints/adapter-test.js
+++ b/node-tests/blueprints/adapter-test.js
@@ -19,7 +19,7 @@ describe('Acceptance: generate and destroy adapter blueprints', function() {
   setupTestHooks(this);
 
   beforeEach(function() {
-    return emberNew();
+    return emberNew().then(() => generateFakePackageManifest('ember-cli-qunit', '4.1.0'));
   });
 
   it('adapter', function() {

--- a/node-tests/blueprints/component-test-test.js
+++ b/node-tests/blueprints/component-test-test.js
@@ -19,7 +19,7 @@ describe('Blueprint: component-test', function() {
 
   describe('in app', function() {
     beforeEach(function() {
-      return emberNew();
+      return emberNew().then(() => generateFakePackageManifest('ember-cli-qunit', '4.1.0'));
     });
 
     it('component-test x-foo', function() {
@@ -135,7 +135,9 @@ describe('Blueprint: component-test', function() {
 
   describe('in addon', function() {
     beforeEach(function() {
-      return emberNew({ target: 'addon' });
+      return emberNew({ target: 'addon' }).then(() =>
+        generateFakePackageManifest('ember-cli-qunit', '4.1.0')
+      );
     });
 
     it('component-test x-foo', function() {
@@ -171,7 +173,9 @@ describe('Blueprint: component-test', function() {
 
   describe('in in-repo-addon', function() {
     beforeEach(function() {
-      return emberNew({ target: 'in-repo-addon' });
+      return emberNew({ target: 'in-repo-addon' }).then(() =>
+        generateFakePackageManifest('ember-cli-qunit', '4.1.0')
+      );
     });
 
     it('component-test x-foo --in-repo-addon=my-addon', function() {

--- a/node-tests/blueprints/controller-test-test.js
+++ b/node-tests/blueprints/controller-test-test.js
@@ -17,7 +17,7 @@ describe('Blueprint: controller-test', function() {
 
   describe('in app', function() {
     beforeEach(function() {
-      return emberNew();
+      return emberNew().then(() => generateFakePackageManifest('ember-cli-qunit', '4.1.0'));
     });
 
     it('controller-test foo', function() {
@@ -81,7 +81,9 @@ describe('Blueprint: controller-test', function() {
 
   describe('in addon', function() {
     beforeEach(function() {
-      return emberNew({ target: 'addon' });
+      return emberNew({ target: 'addon' }).then(() =>
+        generateFakePackageManifest('ember-cli-qunit', '4.1.0')
+      );
     });
 
     it('controller-test foo', function() {

--- a/node-tests/blueprints/initializer-test-test.js
+++ b/node-tests/blueprints/initializer-test-test.js
@@ -17,7 +17,7 @@ describe('Blueprint: initializer-test', function() {
 
   describe('in app', function() {
     beforeEach(function() {
-      return emberNew();
+      return emberNew().then(() => generateFakePackageManifest('ember-cli-qunit', '4.1.0'));
     });
 
     it('initializer-test foo', function() {
@@ -62,7 +62,9 @@ describe('Blueprint: initializer-test', function() {
 
   describe('in addon', function() {
     beforeEach(function() {
-      return emberNew({ target: 'addon' });
+      return emberNew({ target: 'addon' }).then(() =>
+        generateFakePackageManifest('ember-cli-qunit', '4.1.0')
+      );
     });
 
     it('initializer-test foo', function() {

--- a/node-tests/blueprints/initializer-test.js
+++ b/node-tests/blueprints/initializer-test.js
@@ -6,6 +6,8 @@ const emberNew = blueprintHelpers.emberNew;
 const emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
 const setupPodConfig = blueprintHelpers.setupPodConfig;
 
+const generateFakePackageManifest = require('../helpers/generate-fake-package-manifest');
+
 const chai = require('ember-cli-blueprint-test-helpers/chai');
 const expect = chai.expect;
 
@@ -202,12 +204,14 @@ describe('Blueprint: initializer', function() {
     });
 
     it('initializer-test foo', function() {
+      generateFakePackageManifest('ember-cli-qunit', '4.2.0');
+
       return emberGenerateDestroy(['initializer-test', 'foo'], _file => {
         expect(_file('tests/unit/initializers/foo-test.ts'))
           .to.contain("import { initialize } from 'dummy/initializers/foo';")
           .to.contain("module('Unit | Initializer | foo'")
-          .to.contain('application = Application.create();')
-          .to.contain('initialize(this.application);');
+          .to.contain('application = this.TestApplication.create(')
+          .to.contain('this.application.boot()');
       });
     });
   });

--- a/node-tests/blueprints/instance-initializer-test-test.js
+++ b/node-tests/blueprints/instance-initializer-test-test.js
@@ -17,7 +17,7 @@ describe('Blueprint: instance-initializer-test', function() {
 
   describe('in app', function() {
     beforeEach(function() {
-      return emberNew();
+      return emberNew().then(() => generateFakePackageManifest('ember-cli-qunit', '4.1.0'));
     });
 
     it('instance-initializer-test foo', function() {
@@ -62,7 +62,9 @@ describe('Blueprint: instance-initializer-test', function() {
 
   describe('in addon', function() {
     beforeEach(function() {
-      return emberNew({ target: 'addon' });
+      return emberNew({ target: 'addon' }).then(() =>
+        generateFakePackageManifest('ember-cli-qunit', '4.1.0')
+      );
     });
 
     it('instance-initializer-test foo', function() {

--- a/node-tests/blueprints/mixin-test-test.js
+++ b/node-tests/blueprints/mixin-test-test.js
@@ -17,7 +17,7 @@ describe('Blueprint: mixin-test', function() {
 
   describe('in app', function() {
     beforeEach(function() {
-      return emberNew();
+      return emberNew().then(() => generateFakePackageManifest('ember-cli-qunit', '4.1.0'));
     });
 
     it('mixin-test foo', function() {
@@ -56,7 +56,9 @@ describe('Blueprint: mixin-test', function() {
 
   describe('in addon', function() {
     beforeEach(function() {
-      return emberNew({ target: 'addon' });
+      return emberNew({ target: 'addon' }).then(() =>
+        generateFakePackageManifest('ember-cli-qunit', '4.1.0')
+      );
     });
 
     it('mixin-test foo', function() {

--- a/node-tests/blueprints/model-test.js
+++ b/node-tests/blueprints/model-test.js
@@ -16,7 +16,7 @@ describe('Acceptance: generate and destroy model blueprints', function() {
   setupTestHooks(this);
 
   beforeEach(function() {
-    return emberNew();
+    return emberNew().then(() => generateFakePackageManifest('ember-cli-qunit', '4.1.0'));
   });
 
   it('model', function() {

--- a/node-tests/blueprints/route-test-test.js
+++ b/node-tests/blueprints/route-test-test.js
@@ -17,7 +17,7 @@ describe('Blueprint: route-test', function() {
 
   describe('in app', function() {
     beforeEach(function() {
-      return emberNew();
+      return emberNew().then(() => generateFakePackageManifest('ember-cli-qunit', '4.1.0'));
     });
 
     it('route-test foo', function() {
@@ -75,7 +75,9 @@ describe('Blueprint: route-test', function() {
 
   describe('in addon', function() {
     beforeEach(function() {
-      return emberNew({ target: 'addon' });
+      return emberNew({ target: 'addon' }).then(() =>
+        generateFakePackageManifest('ember-cli-qunit', '4.1.0')
+      );
     });
 
     it('route-test foo', function() {

--- a/node-tests/blueprints/route-test.js
+++ b/node-tests/blueprints/route-test.js
@@ -8,6 +8,8 @@ const emberDestroy = blueprintHelpers.emberDestroy;
 const emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
 const setupPodConfig = blueprintHelpers.setupPodConfig;
 
+const generateFakePackageManifest = require('../helpers/generate-fake-package-manifest');
+
 const chai = require('ember-cli-blueprint-test-helpers/chai');
 const expect = chai.expect;
 const file = chai.file;
@@ -18,7 +20,7 @@ describe('Blueprint: route', function() {
 
   describe('in app', function() {
     beforeEach(function() {
-      return emberNew();
+      return emberNew().then(() => generateFakePackageManifest('ember-cli-qunit', '4.1.0'));
     });
 
     it('route foo', function() {
@@ -249,7 +251,7 @@ describe('Blueprint: route', function() {
 
   describe('in addon', function() {
     beforeEach(function() {
-      return emberNew({ target: 'addon' });
+      return emberNew({ target: 'addon' }).then(() => generateFakePackageManifest('ember-cli-qunit', '4.1.0'));
     });
 
     // Skipping these because the reason they're failing is *not* apparent, and

--- a/node-tests/blueprints/serializer-test.js
+++ b/node-tests/blueprints/serializer-test.js
@@ -19,7 +19,7 @@ describe('Acceptance: generate and destroy serializer blueprints', function() {
   setupTestHooks(this);
 
   beforeEach(function() {
-    return emberNew();
+    return emberNew().then(() => generateFakePackageManifest('ember-cli-qunit', '4.1.0'));
   });
 
   it('serializer', function() {

--- a/node-tests/blueprints/transform-test.js
+++ b/node-tests/blueprints/transform-test.js
@@ -17,7 +17,8 @@ describe('Acceptance: generate and destroy transform blueprints', function() {
 
   describe('in app', function() {
     beforeEach(function() {
-      return emberNew();
+      return emberNew()
+        .then(() => generateFakePackageManifest('ember-cli-qunit', '4.1.0'));
     });
 
     it('transform', function() {


### PR DESCRIPTION
We need to be explicit about the ember-cli-qunit version we use in all acceptance tests — otherwise the test framework detector finds the version belonging to the project, which we shouldn't make assumptions about.

@chriskrycho 👋 