### PR TITLE
fix app path for addon in tsconfig

### DIFF
--- a/blueprints/ember-cli-typescript/index.js
+++ b/blueprints/ember-cli-typescript/index.js
@@ -51,7 +51,7 @@ module.exports = {
         }
 
         if (isAddon) {
-          paths[`${appName}/*`] = ['tests/dummy/app/*'];
+          paths[`${appName}/*`] = ['app/*', 'tests/dummy/app/*'];
         } else {
           paths[`${appName}/*`] = ['app/*'];
         }


### PR DESCRIPTION
for an addon, the `/app` folder is also present

the contents of the `/app` folder is merged into the namespace 
of the app that will consume this addon.

So the total namespace of the test app consists of both 
the `/app` folder as well as `/tests/dummy/app` folder