### PR TITLE
Expose app files via a preprocessor so they take precedence

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const IncrementalTypescriptCompiler = require('./lib/incremental-typescript-compiler');
+const Funnel = require('broccoli-funnel');
+const MergeTrees = require('broccoli-merge-trees');
 
 module.exports = {
   name: 'ember-cli-typescript',
@@ -22,6 +24,24 @@ module.exports = {
         'ts:clean': require('./lib/commands/clean'),
       };
     }
+  },
+
+  setupPreprocessorRegistry(type, registry) {
+    if (type !== 'parent') {
+      return;
+    }
+
+    registry.add('js', {
+      name: 'ember-cli-typescript',
+      toTree: (original, inputPath, outputPath) => {
+        if (!this.compiler || inputPath !== '/') {
+          return original;
+        }
+
+        let ts = new Funnel(this.compiler.treeForHost(), { destDir: outputPath });
+        return new MergeTrees([original, ts], { overwrite: true });
+      },
+    });
   },
 
   treeForApp() {

--- a/lib/incremental-typescript-compiler.js
+++ b/lib/incremental-typescript-compiler.js
@@ -38,17 +38,7 @@ module.exports = class IncrementalTypescriptCompiler {
     this._didAutoresolve = false;
   }
 
-  treeForApp() {
-    // This could be more efficient, but we can hopefully assume there won't be dozens
-    // or hundreds of TS addons in dev mode all at once.
-    // Using node-merge-trees in the TypescriptOutput plugin would allow for mappings
-    // like { foo: 'out', bar: 'out' } so we'd only need one Broccoli node for this.
-    let addonAppTrees = this.addons.map(addon => {
-      return new TypescriptOutput(this, {
-        [`${this._relativeAddonRoot(addon)}/app`]: 'app',
-      });
-    });
-
+  treeForHost() {
     let triggerTree = new Funnel(this._triggerDir, { destDir: 'app' });
 
     let appTree = new TypescriptOutput(this, {
@@ -60,8 +50,21 @@ module.exports = class IncrementalTypescriptCompiler {
       [mirage]: 'app/mirage',
     });
 
-    let tree = new MergeTrees(addonAppTrees.concat([triggerTree, appTree, mirageTree].filter(Boolean)), { overwrite: true });
+    let tree = new MergeTrees([triggerTree, mirageTree, appTree].filter(Boolean), { overwrite: true });
     return new Funnel(tree, { srcDir: 'app' });
+  }
+
+  // Returns any developing addons' app trees. Note that the host app itself is managed
+  // by treeForHost() above, as it needs to be treated specially by the build to always
+  // 'win' when the host and an addon have clashing files.
+  treeForApp() {
+    let addonAppTrees = this.addons.map(addon => {
+      return new TypescriptOutput(this, {
+        [`${this._relativeAddonRoot(addon)}/app`]: 'app',
+      });
+    });
+
+    return new MergeTrees(addonAppTrees, { overwrite: true });
   }
 
   treeForAddons() {


### PR DESCRIPTION
Locally, this solves issue number 1 in #126 (addons' `app` files clobbering local ones) for me. @toranb if you have a moment at some point, would you mind giving this branch a spin and confirming?

@chriskrycho I know you said you ran into this as well.