### PR TITLE
Precompile TS files in addons' `app` trees

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,6 +507,8 @@ The `ts:precompile` command will put compiled `.js` files in your `addon` direct
 
 The `ts:clean` command will remove the generated `.js` and `.d.ts` files, leaving your working directory back in a pristine state.
 
+**Note**: While `.ts` files from both the `app` and `addon` directories of your addon will be transpiled by `ts:precompile`, only the declaration files from `addon` will be published. Since the final import paths for `app` files will depend on the name of the consuming application, we can't put those declaration files in a meaningful place.
+
 ### Linking Addons
 
 Often when developing an addon, it can be useful to run that addon in the context of some other host app so you can make sure it will integrate the way you expect, e.g. using [`yarn link`](https://yarnpkg.com/en/docs/cli/link#search) or [`npm link`](https://docs.npmjs.com/cli/link).

--- a/blueprints/ember-cli-typescript/index.js
+++ b/blueprints/ember-cli-typescript/index.js
@@ -31,7 +31,7 @@ module.exports = {
     let inRepoAddons = (this.project.pkg['ember-addon'] || {}).paths || [];
     let hasMirage = 'ember-cli-mirage' in (this.project.pkg.devDependencies || {});
     let isAddon = this.project.isEmberCLIAddon();
-    let includes = [isAddon ? 'addon' : 'app', 'tests'].concat(inRepoAddons);
+    let includes = ['app', isAddon && 'addon', 'tests'].concat(inRepoAddons).filter(Boolean);
 
     // Mirage is already covered for addons because it's under `tests/`
     if (hasMirage && !isAddon) {
@@ -51,7 +51,7 @@ module.exports = {
         }
 
         if (isAddon) {
-          paths[`${appName}/*`] = ['tests/dummy/app/*'];
+          paths[`${appName}/*`] = ['tests/dummy/app/*', 'app/*'];
         } else {
           paths[`${appName}/*`] = ['app/*'];
         }

--- a/lib/commands/precompile.js
+++ b/lib/commands/precompile.js
@@ -6,10 +6,8 @@ const fs = require('fs');
 const path = require('path');
 const walkSync = require('walk-sync');
 const mkdirp = require('mkdirp');
-const SilentError = require('silent-error');
 const Command = require('ember-cli/lib/models/command'); // eslint-disable-line node/no-unpublished-require
 const compile = require('../utilities/compile');
-const debug = require('debug')('ember-cli-typescript:precompile');
 
 const PRECOMPILE_MANIFEST = 'tmp/.ts-precompile-manifest';
 
@@ -30,16 +28,16 @@ module.exports = Command.extend({
     return compile({ project, outDir, flags }).then(() => {
       let output = [];
       for (let declSource of walkSync(outDir, { globs: ['**/*.d.ts'] })) {
-        if (!this._isAddonFile(declSource)) {
-          debug('skipping non-addon file %s', declSource);
-          continue;
+        if (this._shouldCopy(declSource)) {
+          let compiled = declSource.replace(/\.d\.ts$/, '.js');
+          this._copyFile(output, `${outDir}/${compiled}`, compiled);
+
+          // We can only do anything meaningful with declarations for files in addon/
+          if (this._isAddonFile(declSource)) {
+            let declDest = declSource.replace(/^addon\//, '');
+            this._copyFile(output, `${outDir}/${declSource}`, declDest);
+          }
         }
-
-        let declDest = declSource.replace(/^addon\//, '');
-        let compiled = declSource.replace(/\.d\.ts$/, '.js');
-
-        this._copyFile(output, `${outDir}/${declSource}`, declDest);
-        this._copyFile(output, `${outDir}/${compiled}`, compiled);
       }
 
       mkdirp.sync(path.dirname(manifestPath));
@@ -47,14 +45,15 @@ module.exports = Command.extend({
     });
   },
 
-  _isAddonFile(source) {
-    if (source.indexOf('app') === 0) {
-      throw new SilentError(
-        "Including .ts files in your addon's `app` directory is unsupported. " +
-          'See <link to README or something>.'
-      );
-    }
+  _shouldCopy(source) {
+    return this._isAppFile(source) || this._isAddonFile(source);
+  },
 
+  _isAppFile(source) {
+    return source.indexOf('app') === 0;
+  },
+
+  _isAddonFile(source) {
     return source.indexOf('addon') === 0;
   },
 

--- a/node-tests/blueprints/ember-cli-typescript-test.js
+++ b/node-tests/blueprints/ember-cli-typescript-test.js
@@ -68,13 +68,13 @@ describe('Acceptance: ember-cli-typescript generator', function() {
         const tsconfigJson = JSON.parse(tsconfig.content);
         expect(tsconfigJson.compilerOptions.paths).to.deep.equal({
           'dummy/tests/*': ['tests/*'],
-          'dummy/*': ['tests/dummy/app/*'],
+          'dummy/*': ['tests/dummy/app/*', 'app/*'],
           'my-addon': ['addon'],
           'my-addon/*': ['addon/*'],
           '*': ['types/*'],
         });
 
-        expect(tsconfigJson.include).to.deep.equal(['addon', 'tests']);
+        expect(tsconfigJson.include).to.deep.equal(['app', 'addon', 'tests']);
 
         const projectTypes = file('types/dummy/index.d.ts');
         expect(projectTypes).to.exist;
@@ -167,13 +167,13 @@ describe('Acceptance: ember-cli-typescript generator', function() {
         expect(json.compilerOptions.paths).to.deep.equal({
           'dummy/tests/*': ['tests/*'],
           'dummy/mirage/*': ['tests/dummy/mirage/*'],
-          'dummy/*': ['tests/dummy/app/*'],
+          'dummy/*': ['tests/dummy/app/*', 'app/*'],
           'my-addon': ['addon'],
           'my-addon/*': ['addon/*'],
           '*': ['types/*'],
         });
 
-        expect(json.include).to.deep.equal(['addon', 'tests']);
+        expect(json.include).to.deep.equal(['app', 'addon', 'tests']);
       });
   });
 });


### PR DESCRIPTION
In the absence of a way to compose a single TS project with multiple `tsconfig.json`s (see #127), this ensures we transpile any TS files found in addons' `app` trees when doing `ts:precompile`, and adds `app` to the `include` and `paths` setup for addons.

It _doesn't_ update all the blueprints to generate `.ts` files by default for the reexports 😖 