### PR TITLE
Add TestContext type for this in test blueprints

### DIFF
--- a/blueprints/adapter-test/mocha-files/tests/unit/__path__/__test__.ts
+++ b/blueprints/adapter-test/mocha-files/tests/unit/__path__/__test__.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
+import { TestContext } from 'ember-test-helpers';
 
 describe('<%= friendlyTestDescription %>', function() {
   setupTest('adapter:<%= dasherizedModuleName %>', {
@@ -9,7 +10,7 @@ describe('<%= friendlyTestDescription %>', function() {
   });
 
   // Replace this with your real tests.
-  it('exists', function() {
+  it('exists', function(this: TestContext) {
     let adapter = this.subject();
     expect(adapter).to.be.ok;
   });

--- a/blueprints/adapter-test/qunit-files/tests/unit/__path__/__test__.ts
+++ b/blueprints/adapter-test/qunit-files/tests/unit/__path__/__test__.ts
@@ -1,4 +1,5 @@
 import { moduleFor, test } from 'ember-qunit';
+import { TestContext } from 'ember-test-helpers';
 
 moduleFor('adapter:<%= dasherizedModuleName %>', '<%= friendlyTestDescription %>', {
   // Specify the other units that are required for this test.
@@ -6,7 +7,7 @@ moduleFor('adapter:<%= dasherizedModuleName %>', '<%= friendlyTestDescription %>
 });
 
 // Replace this with your real tests.
-test('it exists', function(assert) {
+test('it exists', function(this: TestContext, assert) {
   let adapter = this.subject();
   assert.ok(adapter);
 });

--- a/blueprints/adapter-test/qunit-rfc-232-files/tests/unit/__path__/__test__.ts
+++ b/blueprints/adapter-test/qunit-rfc-232-files/tests/unit/__path__/__test__.ts
@@ -1,11 +1,12 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import { TestContext } from 'ember-test-helpers';
 
 module('<%= friendlyTestDescription %>', function(hooks) {
   setupTest(hooks);
 
   // Replace this with your real tests.
-  test('it exists', function(assert) {
+  test('it exists', function(this: TestContext, assert) {
     let adapter = this.owner.lookup('adapter:<%= dasherizedModuleName %>');
     assert.ok(adapter);
   });

--- a/blueprints/component-test/mocha-0.12-files/tests/__testType__/__path__/__test__.ts
+++ b/blueprints/component-test/mocha-0.12-files/tests/__testType__/__path__/__test__.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupComponentTest } from 'ember-mocha';<% if (testType === 'integration') { %>
 import hbs from 'htmlbars-inline-precompile';<% } %>
+import { TestContext } from 'ember-test-helpers';
 
 describe('<%= friendlyTestDescription %>', function() {
   setupComponentTest('<%= componentPathName %>', {
@@ -10,7 +11,7 @@ describe('<%= friendlyTestDescription %>', function() {
     unit: true<% } %>
   });
 
-  it('renders', function() {
+  it('renders', function(this: TestContext) {
     <% if (testType === 'integration' ) { %>// Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.on('myAction', function(val) { ... });
     // Template block usage:

--- a/blueprints/component-test/mocha-files/tests/__testType__/__path__/__test__.ts
+++ b/blueprints/component-test/mocha-files/tests/__testType__/__path__/__test__.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { describeComponent, it } from 'ember-mocha';<% if (testType === 'integration') { %>
 import hbs from 'htmlbars-inline-precompile';<% } %>
+import { TestContext } from 'ember-test-helpers';
 
 describeComponent('<%= componentPathName %>', '<%= friendlyTestDescription %>',
   {
@@ -9,7 +10,7 @@ describeComponent('<%= componentPathName %>', '<%= friendlyTestDescription %>',
     unit: true<% } %>
   },
   function() {
-    it('renders', function() {
+    it('renders', function(this: TestContext) {
       <% if (testType === 'integration' ) { %>// Set any properties with this.set('myProperty', 'value');
       // Handle any actions with this.on('myAction', function(val) { ... });
       // Template block usage:

--- a/blueprints/component-test/qunit-files/tests/__testType__/__path__/__test__.ts
+++ b/blueprints/component-test/qunit-files/tests/__testType__/__path__/__test__.ts
@@ -1,5 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit';<% if (testType === 'integration') { %>
 import hbs from 'htmlbars-inline-precompile';<% } %>
+import { TestContext } from 'ember-test-helpers';
 
 moduleForComponent('<%= componentPathName %>', '<%= friendlyTestDescription %>', {
   <% if (testType === 'integration' ) { %>integration: true<% } else if(testType === 'unit') { %>// Specify the other units that are required for this test
@@ -7,7 +8,7 @@ moduleForComponent('<%= componentPathName %>', '<%= friendlyTestDescription %>',
   unit: true<% } %>
 });
 
-test('it renders', function(assert) {
+test('it renders', function(this: TestContext, assert) {
   <% if (testType === 'integration' ) { %>// Set any properties with this.set('myProperty', 'value');
   // Handle any actions with this.on('myAction', function(val) { ... });
 

--- a/blueprints/component-test/qunit-rfc-232-files/tests/__testType__/__path__/__test__.ts
+++ b/blueprints/component-test/qunit-rfc-232-files/tests/__testType__/__path__/__test__.ts
@@ -2,11 +2,12 @@
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import { TestContext } from 'ember-test-helpers';
 
 module('<%= friendlyTestDescription %>', function(hooks) {
   setupRenderingTest(hooks);
 
-  test('it renders', async function(assert) {
+  test('it renders', async function(this: TestContext, assert) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
 
@@ -25,11 +26,12 @@ module('<%= friendlyTestDescription %>', function(hooks) {
   });
 });<% } else if (testType === 'unit') { %>import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import { TestContext } from 'ember-test-helpers';
 
 module('<%= friendlyTestDescription %>', function(hooks) {
   setupTest(hooks);
 
-  test('it exists', function(assert) {
+  test('it exists', function(this: TestContext, assert) {
     let component = this.owner.factoryFor('component:<%= componentPathName %>').create();
     assert.ok(component);
   });

--- a/blueprints/controller-test/mocha-0.12-files/tests/unit/__path__/__test__.ts
+++ b/blueprints/controller-test/mocha-0.12-files/tests/unit/__path__/__test__.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
+import { TestContext } from 'ember-test-helpers';
 
 describe('<%= friendlyTestDescription %>', function() {
   setupTest('controller:<%= dasherizedModuleName %>', {
@@ -9,7 +10,7 @@ describe('<%= friendlyTestDescription %>', function() {
   });
 
   // Replace this with your real tests.
-  it('exists', function() {
+  it('exists', function(this: TestContext) {
     let controller = this.subject();
     expect(controller).to.be.ok;
   });

--- a/blueprints/controller-test/mocha-files/tests/unit/__path__/__test__.ts
+++ b/blueprints/controller-test/mocha-files/tests/unit/__path__/__test__.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import { describeModule, it } from 'ember-mocha';
+import { TestContext } from 'ember-test-helpers';
 
 describeModule('controller:<%= dasherizedModuleName %>', '<%= friendlyTestDescription %>',
   {
@@ -8,7 +9,7 @@ describeModule('controller:<%= dasherizedModuleName %>', '<%= friendlyTestDescri
   },
   function() {
     // Replace this with your real tests.
-    it('exists', function() {
+    it('exists', function(this: TestContext) {
       let controller = this.subject();
       expect(controller).to.be.ok;
     });

--- a/blueprints/controller-test/qunit-files/tests/unit/__path__/__test__.ts
+++ b/blueprints/controller-test/qunit-files/tests/unit/__path__/__test__.ts
@@ -1,4 +1,5 @@
 import { moduleFor, test } from 'ember-qunit';
+import { TestContext } from 'ember-test-helpers';
 
 moduleFor('controller:<%= dasherizedModuleName %>', '<%= friendlyTestDescription %>', {
   // Specify the other units that are required for this test.
@@ -6,7 +7,7 @@ moduleFor('controller:<%= dasherizedModuleName %>', '<%= friendlyTestDescription
 });
 
 // Replace this with your real tests.
-test('it exists', function(assert) {
+test('it exists', function(this: TestContext, assert) {
   let controller = this.subject();
   assert.ok(controller);
 });

--- a/blueprints/controller-test/qunit-rfc-232-files/tests/unit/__path__/__test__.ts
+++ b/blueprints/controller-test/qunit-rfc-232-files/tests/unit/__path__/__test__.ts
@@ -1,11 +1,12 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import { TestContext } from 'ember-test-helpers';
 
 module('<%= friendlyTestDescription %>', function(hooks) {
   setupTest(hooks);
 
   // Replace this with your real tests.
-  test('it exists', function(assert) {
+  test('it exists', function(this: TestContext, assert) {
     let controller = this.owner.lookup('controller:<%= controllerPathName %>');
     assert.ok(controller);
   });

--- a/blueprints/helper-test/mocha-0.12-files/tests/__testType__/helpers/__name__-test.ts
+++ b/blueprints/helper-test/mocha-0.12-files/tests/__testType__/helpers/__name__-test.ts
@@ -2,13 +2,14 @@ import { expect } from 'chai';
 <% if (testType == 'integration') { %>import { describe, it } from 'mocha';
 import { setupComponentTest } from 'ember-mocha';
 import hbs from 'htmlbars-inline-precompile';
+import { TestContext } from 'ember-test-helpers';
 
 describe('<%= friendlyTestName %>', function() {
   setupComponentTest('<%= dasherizedModuleName %>', {
     integration: true
   });
 
-  it('renders', function() {
+  it('renders', function(this: TestContext) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.on('myAction', function(val) { ... });
     // Template block usage:

--- a/blueprints/helper-test/mocha-files/tests/__testType__/helpers/__name__-test.ts
+++ b/blueprints/helper-test/mocha-files/tests/__testType__/helpers/__name__-test.ts
@@ -2,13 +2,14 @@ import { expect } from 'chai';
 <% if (testType == 'integration') { %>
 import { describeComponent, it } from 'ember-mocha';
 import hbs from 'htmlbars-inline-precompile';
+import { TestContext } from 'ember-test-helpers';
 
 describeComponent('<%= dasherizedModuleName %>', 'helper:<%= dasherizedModuleName %>',
   {
     integration: true
   },
   function() {
-    it('renders', function() {
+    it('renders', function(this: TestContext) {
       // Set any properties with this.set('myProperty', 'value');
       // Handle any actions with this.on('myAction', function(val) { ... });
       // Template block usage:

--- a/blueprints/helper-test/qunit-files/tests/__testType__/helpers/__name__-test.ts
+++ b/blueprints/helper-test/qunit-files/tests/__testType__/helpers/__name__-test.ts
@@ -1,12 +1,13 @@
 <% if (testType == 'integration') { %>import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { TestContext } from 'ember-test-helpers';
 
 moduleForComponent('<%= dasherizedModuleName %>', 'helper:<%= dasherizedModuleName %>', {
   integration: true
 });
 
 // Replace this with your real tests.
-test('it renders', function(assert) {
+test('it renders', function(this: TestContext, assert) {
   this.set('inputValue', '1234');
 
   this.render(hbs`{{<%= dasherizedModuleName %> inputValue}}`);

--- a/blueprints/helper-test/qunit-rfc-232-files/tests/__testType__/helpers/__name__-test.ts
+++ b/blueprints/helper-test/qunit-rfc-232-files/tests/__testType__/helpers/__name__-test.ts
@@ -2,12 +2,13 @@
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import { TestContext } from 'ember-test-helpers';
 
 module('<%= friendlyTestName %>', function(hooks) {
   setupRenderingTest(hooks);
 
   // Replace this with your real tests.
-  test('it renders', async function(assert) {
+  test('it renders', async function(this: TestContext, assert) {
     this.set('inputValue', '1234');
 
     await render(hbs`{{<%= dasherizedModuleName %> inputValue}}`);

--- a/blueprints/initializer-test/qunit-files/tests/unit/initializers/__test__.ts
+++ b/blueprints/initializer-test/qunit-files/tests/unit/initializers/__test__.ts
@@ -4,21 +4,22 @@ import { run } from '@ember/runloop';
 import { initialize } from '<%= dasherizedModulePrefix %>/initializers/<%= dasherizedModuleName %>';
 import { module, test } from 'qunit';
 import destroyApp from '../../helpers/destroy-app';
+import { TestContext } from 'ember-test-helpers';
 
 module('<%= friendlyTestName %>', {
-  beforeEach() {
+  beforeEach(this: TestContext) {
     run(() => {
       this.application = Application.create();
       this.application.deferReadiness();
     });
   },
-  afterEach() {
+  afterEach(this: TestContext) {
     destroyApp(this.application);
   }
 });
 
 // Replace this with your real tests.
-test('it works', function(assert) {
+test('it works', function(this: TestContext, assert) {
   initialize(this.application);
 
   // you would normally confirm the results of the initializer here

--- a/blueprints/initializer-test/qunit-rfc-232-files/tests/unit/initializers/__test__.ts
+++ b/blueprints/initializer-test/qunit-rfc-232-files/tests/unit/initializers/__test__.ts
@@ -4,11 +4,12 @@ import { initialize } from '<%= dasherizedModulePrefix %>/initializers/<%= dashe
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import destroyApp from '../../helpers/destroy-app';
+import { TestContext } from 'ember-test-helpers';
 
 module('<%= friendlyTestName %>', function(hooks) {
   setupTest(hooks);
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function(this: TestContext) {
     this.TestApplication = Application.extend();
     this.TestApplication.initializer({
       name: 'initializer under test',
@@ -18,12 +19,12 @@ module('<%= friendlyTestName %>', function(hooks) {
     this.application = this.TestApplication.create({ autoboot: false });
   });
 
-  hooks.afterEach(function() {
+  hooks.afterEach(function(this: TestContext) {
     destroyApp(this.application);
   });
 
   // Replace this with your real tests.
-  test('it works', async function(assert) {
+  test('it works', async function(this: TestContext, assert) {
     await this.application.boot();
 
     assert.ok(true);

--- a/blueprints/instance-initializer-test/qunit-files/tests/unit/instance-initializers/__name__-test.ts
+++ b/blueprints/instance-initializer-test/qunit-files/tests/unit/instance-initializers/__name__-test.ts
@@ -3,22 +3,23 @@ import { run } from '@ember/runloop';
 import { initialize } from '<%= dasherizedModulePrefix %>/instance-initializers/<%= dasherizedModuleName %>';
 import { module, test } from 'qunit';
 import destroyApp from '../../helpers/destroy-app';
+import { TestContext } from 'ember-test-helpers';
 
 module('<%= friendlyTestName %>', {
-  beforeEach() {
+  beforeEach(this: TestContext) {
     run(() => {
       this.application = Application.create();
       this.appInstance = this.application.buildInstance();
     });
   },
-  afterEach() {
+  afterEach(this: TestContext) {
     run(this.appInstance, 'destroy');
     destroyApp(this.application);
   }
 });
 
 // Replace this with your real tests.
-test('it works', function(assert) {
+test('it works', function(this: TestContext, assert) {
   initialize(this.appInstance);
 
   // you would normally confirm the results of the initializer here

--- a/blueprints/instance-initializer-test/qunit-rfc-232-files/tests/unit/instance-initializers/__name__-test.ts
+++ b/blueprints/instance-initializer-test/qunit-rfc-232-files/tests/unit/instance-initializers/__name__-test.ts
@@ -4,11 +4,12 @@ import { initialize } from '<%= dasherizedModulePrefix %>/instance-initializers/
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import destroyApp from '../../helpers/destroy-app';
+import { TestContext } from 'ember-test-helpers';
 
 module('<%= friendlyTestName %>', function(hooks) {
   setupTest(hooks);
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function(this: TestContext) {
     this.TestApplication = Application.extend();
     this.TestApplication.instanceInitializer({
       name: 'initializer under test',
@@ -17,13 +18,13 @@ module('<%= friendlyTestName %>', function(hooks) {
     this.application = this.TestApplication.create({ autoboot: false });
     this.instance = this.application.buildInstance();
   });
-  hooks.afterEach(function() {
+  hooks.afterEach(function(this: TestContext) {
     destroyApp(this.application);
     destroyApp(this.instance);
   });
 
   // Replace this with your real tests.
-  test('it works', async function(assert) {
+  test('it works', async function(this: TestContext, assert) {
     await this.instance.boot();
 
     assert.ok(true);

--- a/blueprints/model-test/mocha-files/tests/unit/__path__/__test__.ts
+++ b/blueprints/model-test/mocha-files/tests/unit/__path__/__test__.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupModelTest } from 'ember-mocha';
+import { TestContext } from 'ember-test-helpers';
 
 describe('<%= friendlyTestDescription %>', function() {
   setupModelTest('<%= dasherizedModuleName %>', {
@@ -9,7 +10,7 @@ describe('<%= friendlyTestDescription %>', function() {
   });
 
   // Replace this with your real tests.
-  it('exists', function() {
+  it('exists', function(this: TestContext) {
     let model = this.subject();
     // var store = this.store();
     expect(model).to.be.ok;

--- a/blueprints/model-test/qunit-files/tests/unit/__path__/__test__.ts
+++ b/blueprints/model-test/qunit-files/tests/unit/__path__/__test__.ts
@@ -1,11 +1,12 @@
 import { moduleForModel, test } from 'ember-qunit';
+import { TestContext } from 'ember-test-helpers';
 
 moduleForModel('<%= dasherizedModuleName %>', '<%= friendlyTestDescription %>', {
   // Specify the other units that are required for this test.
 <%= typeof needs !== 'undefined' ? needs : '' %>
 });
 
-test('it exists', function(assert) {
+test('it exists', function(this: TestContext, assert) {
   let model = this.subject();
   // let store = this.store();
   assert.ok(!!model);

--- a/blueprints/model-test/qunit-rfc-232-files/tests/unit/__path__/__test__.ts
+++ b/blueprints/model-test/qunit-rfc-232-files/tests/unit/__path__/__test__.ts
@@ -1,12 +1,13 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { run } from '@ember/runloop';
+import { TestContext } from 'ember-test-helpers';
 
 module('<%= friendlyTestDescription %>', function(hooks) {
   setupTest(hooks);
 
   // Replace this with your real tests.
-  test('it exists', function(assert) {
+  test('it exists', function(this: TestContext, assert) {
     let store = this.owner.lookup('service:store');
     let model = run(() => store.createRecord('<%= dasherizedModuleName %>', {}));
     assert.ok(model);

--- a/blueprints/route-test/mocha-0.12-files/tests/unit/__path__/__test__.ts
+++ b/blueprints/route-test/mocha-0.12-files/tests/unit/__path__/__test__.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
+import { TestContext } from 'ember-test-helpers';
 
 describe('<%= friendlyTestDescription %>', function() {
   setupTest('route:<%= moduleName %>', {
@@ -8,7 +9,7 @@ describe('<%= friendlyTestDescription %>', function() {
     // needs: ['controller:foo']
   });
 
-  it('exists', function() {
+  it('exists', function(this: TestContext) {
     let route = this.subject();
     expect(route).to.be.ok;
   });

--- a/blueprints/route-test/mocha-files/tests/unit/__path__/__test__.ts
+++ b/blueprints/route-test/mocha-files/tests/unit/__path__/__test__.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import { describeModule, it } from 'ember-mocha';
+import { TestContext } from 'ember-test-helpers';
 
 describeModule('route:<%= moduleName %>', '<%= friendlyTestDescription %>',
   {
@@ -7,7 +8,7 @@ describeModule('route:<%= moduleName %>', '<%= friendlyTestDescription %>',
     // needs: ['controller:foo']
   },
   function() {
-    it('exists', function() {
+    it('exists', function(this: TestContext) {
       let route = this.subject();
       expect(route).to.be.ok;
     });

--- a/blueprints/route-test/qunit-files/tests/unit/__path__/__test__.ts
+++ b/blueprints/route-test/qunit-files/tests/unit/__path__/__test__.ts
@@ -1,11 +1,12 @@
 import { moduleFor, test } from 'ember-qunit';
+import { TestContext } from 'ember-test-helpers';
 
 moduleFor('route:<%= moduleName %>', '<%= friendlyTestDescription %>', {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
 });
 
-test('it exists', function(assert) {
+test('it exists', function(this: TestContext, assert) {
   let route = this.subject();
   assert.ok(route);
 });

--- a/blueprints/route-test/qunit-rfc-232-files/tests/unit/__path__/__test__.ts
+++ b/blueprints/route-test/qunit-rfc-232-files/tests/unit/__path__/__test__.ts
@@ -1,10 +1,11 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import { TestContext } from 'ember-test-helpers';
 
 module('<%= friendlyTestDescription %>', function(hooks) {
   setupTest(hooks);
 
-  test('it exists', function(assert) {
+  test('it exists', function(this: TestContext, assert) {
     let route = this.owner.lookup('route:<%= moduleName %>');
     assert.ok(route);
   });

--- a/blueprints/serializer-test/mocha-files/tests/unit/__path__/__test__.ts
+++ b/blueprints/serializer-test/mocha-files/tests/unit/__path__/__test__.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupModelTest } from 'ember-mocha';
+import { TestContext } from 'ember-test-helpers';
 
 describe('<%= friendlyTestDescription %>', function() {
   setupModelTest('<%= dasherizedModuleName %>', {
@@ -9,7 +10,7 @@ describe('<%= friendlyTestDescription %>', function() {
   });
 
   // Replace this with your real tests.
-  it('serializes records', function() {
+  it('serializes records', function(this: TestContext) {
     let record = this.subject();
 
     let serializedRecord = record.serialize();

--- a/blueprints/serializer-test/qunit-files/tests/unit/__path__/__test__.ts
+++ b/blueprints/serializer-test/qunit-files/tests/unit/__path__/__test__.ts
@@ -1,4 +1,5 @@
 import { moduleForModel, test } from 'ember-qunit';
+import { TestContext } from 'ember-test-helpers';
 
 moduleForModel('<%= dasherizedModuleName %>', '<%= friendlyTestDescription %>', {
   // Specify the other units that are required for this test.
@@ -6,7 +7,7 @@ moduleForModel('<%= dasherizedModuleName %>', '<%= friendlyTestDescription %>', 
 });
 
 // Replace this with your real tests.
-test('it serializes records', function(assert) {
+test('it serializes records', function(this: TestContext, assert) {
   let record = this.subject();
 
   let serializedRecord = record.serialize();

--- a/blueprints/serializer-test/qunit-rfc-232-files/tests/unit/__path__/__test__.ts
+++ b/blueprints/serializer-test/qunit-rfc-232-files/tests/unit/__path__/__test__.ts
@@ -1,19 +1,20 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { run } from '@ember/runloop';
+import { TestContext } from 'ember-test-helpers';
 
 module('<%= friendlyTestDescription %>', function(hooks) {
   setupTest(hooks);
 
   // Replace this with your real tests.
-  test('it exists', function(assert) {
+  test('it exists', function(this: TestContext, assert) {
     let store = this.owner.lookup('service:store');
     let serializer = store.serializerFor('<%= dasherizedModuleName %>');
 
     assert.ok(serializer);
   });
 
-  test('it serializes records', function(assert) {
+  test('it serializes records', function(this: TestContext, assert) {
     let store = this.owner.lookup('service:store');
     let record = run(() => store.createRecord('<%= dasherizedModuleName %>', {}));
 

--- a/blueprints/service-test/mocha-0.12-files/tests/unit/__path__/__test__.ts
+++ b/blueprints/service-test/mocha-0.12-files/tests/unit/__path__/__test__.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
+import { TestContext } from 'ember-test-helpers';
 
 describe('<%= friendlyTestDescription %>', function() {
   setupTest('service:<%= dasherizedModuleName %>', {
@@ -9,7 +10,7 @@ describe('<%= friendlyTestDescription %>', function() {
   });
 
   // Replace this with your real tests.
-  it('exists', function() {
+  it('exists', function(this: TestContext) {
     let service = this.subject();
     expect(service).to.be.ok;
   });

--- a/blueprints/service-test/mocha-files/tests/unit/__path__/__test__.ts
+++ b/blueprints/service-test/mocha-files/tests/unit/__path__/__test__.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import { describeModule, it } from 'ember-mocha';
+import { TestContext } from 'ember-test-helpers';
 
 describeModule('service:<%= dasherizedModuleName %>', '<%= friendlyTestDescription %>',
   {
@@ -8,7 +9,7 @@ describeModule('service:<%= dasherizedModuleName %>', '<%= friendlyTestDescripti
   },
   function() {
     // Replace this with your real tests.
-    it('exists', function() {
+    it('exists', function(this: TestContext) {
       let service = this.subject();
       expect(service).to.be.ok;
     });

--- a/blueprints/service-test/qunit-files/tests/unit/__path__/__test__.ts
+++ b/blueprints/service-test/qunit-files/tests/unit/__path__/__test__.ts
@@ -1,4 +1,5 @@
 import { moduleFor, test } from 'ember-qunit';
+import { TestContext } from 'ember-test-helpers';
 
 moduleFor('service:<%= dasherizedModuleName %>', '<%= friendlyTestDescription %>', {
   // Specify the other units that are required for this test.
@@ -6,7 +7,7 @@ moduleFor('service:<%= dasherizedModuleName %>', '<%= friendlyTestDescription %>
 });
 
 // Replace this with your real tests.
-test('it exists', function(assert) {
+test('it exists', function(this: TestContext, assert) {
   let service = this.subject();
   assert.ok(service);
 });

--- a/blueprints/service-test/qunit-rfc-232-files/tests/unit/__path__/__test__.ts
+++ b/blueprints/service-test/qunit-rfc-232-files/tests/unit/__path__/__test__.ts
@@ -1,11 +1,12 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import { TestContext } from 'ember-test-helpers';
 
 module('<%= friendlyTestDescription %>', function(hooks) {
   setupTest(hooks);
 
   // Replace this with your real tests.
-  test('it exists', function(assert) {
+  test('it exists', function(this: TestContext, assert) {
     let service = this.owner.lookup('service:<%= dasherizedModuleName %>');
     assert.ok(service);
   });

--- a/blueprints/transform-test/mocha-files/tests/unit/__path__/__test__.ts
+++ b/blueprints/transform-test/mocha-files/tests/unit/__path__/__test__.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
+import { TestContext } from 'ember-test-helpers';
 
 describe('<%= friendlyTestDescription %>', function() {
   setupTest('transform:<%= dasherizedModuleName %>', {
@@ -9,7 +10,7 @@ describe('<%= friendlyTestDescription %>', function() {
   });
 
   // Replace this with your real tests.
-  it('exists', function() {
+  it('exists', function(this: TestContext) {
     let transform = this.subject();
     expect(transform).to.be.ok;
   });

--- a/blueprints/transform-test/qunit-files/tests/unit/__path__/__test__.ts
+++ b/blueprints/transform-test/qunit-files/tests/unit/__path__/__test__.ts
@@ -1,4 +1,5 @@
 import { moduleFor, test } from 'ember-qunit';
+import { TestContext } from 'ember-test-helpers';
 
 moduleFor('transform:<%= dasherizedModuleName %>', '<%= friendlyTestDescription %>', {
   // Specify the other units that are required for this test.
@@ -6,7 +7,7 @@ moduleFor('transform:<%= dasherizedModuleName %>', '<%= friendlyTestDescription 
 });
 
 // Replace this with your real tests.
-test('it exists', function(assert) {
+test('it exists', function(this: TestContext, assert) {
   let transform = this.subject();
   assert.ok(transform);
 });

--- a/blueprints/transform-test/qunit-rfc-232-files/tests/unit/__path__/__test__.ts
+++ b/blueprints/transform-test/qunit-rfc-232-files/tests/unit/__path__/__test__.ts
@@ -1,11 +1,12 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import { TestContext } from 'ember-test-helpers';
 
 module('transform:<%= dasherizedModuleName %>', '<%= friendlyTestDescription %>', function(hooks) {
   setupTest(hooks);
 
   // Replace this with your real tests.
-  test('it exists', function(assert) {
+  test('it exists', function(this: TestContext, assert) {
     let transform = this.owner.lookup('transform:<%= dasherizedModuleName %>');
     assert.ok(transform);
   });

--- a/node-tests/fixtures/adapter-test/application-default.ts
+++ b/node-tests/fixtures/adapter-test/application-default.ts
@@ -1,4 +1,5 @@
 import { moduleFor, test } from 'ember-qunit';
+import { TestContext } from 'ember-test-helpers';
 
 moduleFor('adapter:application', 'Unit | Adapter | application', {
   // Specify the other units that are required for this test.
@@ -6,7 +7,7 @@ moduleFor('adapter:application', 'Unit | Adapter | application', {
 });
 
 // Replace this with your real tests.
-test('it exists', function(assert) {
+test('it exists', function(this: TestContext, assert) {
   let adapter = this.subject();
   assert.ok(adapter);
 });

--- a/node-tests/fixtures/adapter-test/foo-default.ts
+++ b/node-tests/fixtures/adapter-test/foo-default.ts
@@ -1,4 +1,5 @@
 import { moduleFor, test } from 'ember-qunit';
+import { TestContext } from 'ember-test-helpers';
 
 moduleFor('adapter:foo', 'Unit | Adapter | foo', {
   // Specify the other units that are required for this test.
@@ -6,7 +7,7 @@ moduleFor('adapter:foo', 'Unit | Adapter | foo', {
 });
 
 // Replace this with your real tests.
-test('it exists', function(assert) {
+test('it exists', function(this: TestContext, assert) {
   let adapter = this.subject();
   assert.ok(adapter);
 });

--- a/node-tests/fixtures/adapter-test/foo-mocha-0.12.ts
+++ b/node-tests/fixtures/adapter-test/foo-mocha-0.12.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
+import { TestContext } from 'ember-test-helpers';
 
 describe('Unit | Adapter | foo', function() {
   setupTest('adapter:foo', {
@@ -9,7 +10,7 @@ describe('Unit | Adapter | foo', function() {
   });
 
   // Replace this with your real tests.
-  it('exists', function() {
+  it('exists', function(this: TestContext) {
     let adapter = this.subject();
     expect(adapter).to.be.ok;
   });

--- a/node-tests/fixtures/adapter-test/rfc232.ts
+++ b/node-tests/fixtures/adapter-test/rfc232.ts
@@ -1,11 +1,12 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import { TestContext } from 'ember-test-helpers';
 
 module('Unit | Adapter | foo', function(hooks) {
   setupTest(hooks);
 
   // Replace this with your real tests.
-  test('it exists', function(assert) {
+  test('it exists', function(this: TestContext, assert) {
     let adapter = this.owner.lookup('adapter:foo');
     assert.ok(adapter);
   });

--- a/node-tests/fixtures/component-test/default.ts
+++ b/node-tests/fixtures/component-test/default.ts
@@ -1,11 +1,12 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { TestContext } from 'ember-test-helpers';
 
 moduleForComponent('x-foo', 'Integration | Component | x-foo', {
   integration: true
 });
 
-test('it renders', function(assert) {
+test('it renders', function(this: TestContext, assert) {
   // Set any properties with this.set('myProperty', 'value');
   // Handle any actions with this.on('myAction', function(val) { ... });
 

--- a/node-tests/fixtures/component-test/mocha-0.12-unit.ts
+++ b/node-tests/fixtures/component-test/mocha-0.12-unit.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupComponentTest } from 'ember-mocha';
+import { TestContext } from 'ember-test-helpers';
 
 describe('Unit | Component | x-foo', function() {
   setupComponentTest('x-foo', {
@@ -9,7 +10,7 @@ describe('Unit | Component | x-foo', function() {
     unit: true
   });
 
-  it('renders', function() {
+  it('renders', function(this: TestContext) {
     // creates the component instance
     let component = this.subject();
     // renders the component on the page

--- a/node-tests/fixtures/component-test/mocha-0.12.ts
+++ b/node-tests/fixtures/component-test/mocha-0.12.ts
@@ -2,13 +2,14 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupComponentTest } from 'ember-mocha';
 import hbs from 'htmlbars-inline-precompile';
+import { TestContext } from 'ember-test-helpers';
 
 describe('Integration | Component | x-foo', function() {
   setupComponentTest('x-foo', {
     integration: true
   });
 
-  it('renders', function() {
+  it('renders', function(this: TestContext) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.on('myAction', function(val) { ... });
     // Template block usage:

--- a/node-tests/fixtures/component-test/mocha-unit.ts
+++ b/node-tests/fixtures/component-test/mocha-unit.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import { describeComponent, it } from 'ember-mocha';
+import { TestContext } from 'ember-test-helpers';
 
 describeComponent('x-foo', 'Unit | Component | x-foo',
   {
@@ -8,7 +9,7 @@ describeComponent('x-foo', 'Unit | Component | x-foo',
     unit: true
   },
   function() {
-    it('renders', function() {
+    it('renders', function(this: TestContext) {
       // creates the component instance
       let component = this.subject();
       // renders the component on the page

--- a/node-tests/fixtures/component-test/mocha.ts
+++ b/node-tests/fixtures/component-test/mocha.ts
@@ -1,13 +1,14 @@
 import { expect } from 'chai';
 import { describeComponent, it } from 'ember-mocha';
 import hbs from 'htmlbars-inline-precompile';
+import { TestContext } from 'ember-test-helpers';
 
 describeComponent('x-foo', 'Integration | Component | x-foo',
   {
     integration: true
   },
   function() {
-    it('renders', function() {
+    it('renders', function(this: TestContext) {
       // Set any properties with this.set('myProperty', 'value');
       // Handle any actions with this.on('myAction', function(val) { ... });
       // Template block usage:

--- a/node-tests/fixtures/component-test/rfc232-unit.ts
+++ b/node-tests/fixtures/component-test/rfc232-unit.ts
@@ -1,10 +1,11 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import { TestContext } from 'ember-test-helpers';
 
 module('Unit | Component | x-foo', function(hooks) {
   setupTest(hooks);
 
-  test('it exists', function(assert) {
+  test('it exists', function(this: TestContext, assert) {
     let component = this.owner.factoryFor('component:x-foo').create();
     assert.ok(component);
   });

--- a/node-tests/fixtures/component-test/rfc232.ts
+++ b/node-tests/fixtures/component-test/rfc232.ts
@@ -2,11 +2,12 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import { TestContext } from 'ember-test-helpers';
 
 module('Integration | Component | x-foo', function(hooks) {
   setupRenderingTest(hooks);
 
-  test('it renders', async function(assert) {
+  test('it renders', async function(this: TestContext, assert) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
 

--- a/node-tests/fixtures/component-test/unit.ts
+++ b/node-tests/fixtures/component-test/unit.ts
@@ -1,4 +1,5 @@
 import { moduleForComponent, test } from 'ember-qunit';
+import { TestContext } from 'ember-test-helpers';
 
 moduleForComponent('x-foo', 'Unit | Component | x-foo', {
   // Specify the other units that are required for this test
@@ -6,7 +7,7 @@ moduleForComponent('x-foo', 'Unit | Component | x-foo', {
   unit: true
 });
 
-test('it renders', function(assert) {
+test('it renders', function(this: TestContext, assert) {
   
   // Creates the component instance
   /*let component =*/ this.subject();

--- a/node-tests/fixtures/controller-test/default.ts
+++ b/node-tests/fixtures/controller-test/default.ts
@@ -1,4 +1,5 @@
 import { moduleFor, test } from 'ember-qunit';
+import { TestContext } from 'ember-test-helpers';
 
 moduleFor('controller:foo', 'Unit | Controller | foo', {
   // Specify the other units that are required for this test.
@@ -6,7 +7,7 @@ moduleFor('controller:foo', 'Unit | Controller | foo', {
 });
 
 // Replace this with your real tests.
-test('it exists', function(assert) {
+test('it exists', function(this: TestContext, assert) {
   let controller = this.subject();
   assert.ok(controller);
 });

--- a/node-tests/fixtures/controller-test/mocha-0.12.ts
+++ b/node-tests/fixtures/controller-test/mocha-0.12.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
+import { TestContext } from 'ember-test-helpers';
 
 describe('Unit | Controller | foo', function() {
   setupTest('controller:foo', {
@@ -9,7 +10,7 @@ describe('Unit | Controller | foo', function() {
   });
 
   // Replace this with your real tests.
-  it('exists', function() {
+  it('exists', function(this: TestContext) {
     let controller = this.subject();
     expect(controller).to.be.ok;
   });

--- a/node-tests/fixtures/controller-test/mocha.ts
+++ b/node-tests/fixtures/controller-test/mocha.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import { describeModule, it } from 'ember-mocha';
+import { TestContext } from 'ember-test-helpers';
 
 describeModule('controller:foo', 'Unit | Controller | foo',
   {
@@ -8,7 +9,7 @@ describeModule('controller:foo', 'Unit | Controller | foo',
   },
   function() {
     // Replace this with your real tests.
-    it('exists', function() {
+    it('exists', function(this: TestContext) {
       let controller = this.subject();
       expect(controller).to.be.ok;
     });

--- a/node-tests/fixtures/controller-test/rfc232.ts
+++ b/node-tests/fixtures/controller-test/rfc232.ts
@@ -1,11 +1,12 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import { TestContext } from 'ember-test-helpers';
 
 module('Unit | Controller | foo', function(hooks) {
   setupTest(hooks);
 
   // Replace this with your real tests.
-  test('it exists', function(assert) {
+  test('it exists', function(this: TestContext, assert) {
     let controller = this.owner.lookup('controller:foo');
     assert.ok(controller);
   });

--- a/node-tests/fixtures/helper-test/integration.ts
+++ b/node-tests/fixtures/helper-test/integration.ts
@@ -1,12 +1,13 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { TestContext } from 'ember-test-helpers';
 
 moduleForComponent('foo/bar-baz', 'helper:foo/bar-baz', {
   integration: true
 });
 
 // Replace this with your real tests.
-test('it renders', function(assert) {
+test('it renders', function(this: TestContext, assert) {
   this.set('inputValue', '1234');
 
   this.render(hbs`{{foo/bar-baz inputValue}}`);

--- a/node-tests/fixtures/helper-test/mocha-0.12.ts
+++ b/node-tests/fixtures/helper-test/mocha-0.12.ts
@@ -2,13 +2,14 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupComponentTest } from 'ember-mocha';
 import hbs from 'htmlbars-inline-precompile';
+import { TestContext } from 'ember-test-helpers';
 
 describe('Integration | Helper | foo/bar-baz', function() {
   setupComponentTest('foo/bar-baz', {
     integration: true
   });
 
-  it('renders', function() {
+  it('renders', function(this: TestContext) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.on('myAction', function(val) { ... });
     // Template block usage:

--- a/node-tests/fixtures/helper-test/mocha.ts
+++ b/node-tests/fixtures/helper-test/mocha.ts
@@ -2,13 +2,14 @@ import { expect } from 'chai';
 
 import { describeComponent, it } from 'ember-mocha';
 import hbs from 'htmlbars-inline-precompile';
+import { TestContext } from 'ember-test-helpers';
 
 describeComponent('foo/bar-baz', 'helper:foo/bar-baz',
   {
     integration: true
   },
   function() {
-    it('renders', function() {
+    it('renders', function(this: TestContext) {
       // Set any properties with this.set('myProperty', 'value');
       // Handle any actions with this.on('myAction', function(val) { ... });
       // Template block usage:

--- a/node-tests/fixtures/helper-test/rfc232.ts
+++ b/node-tests/fixtures/helper-test/rfc232.ts
@@ -2,12 +2,13 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import { TestContext } from 'ember-test-helpers';
 
 module('Integration | Helper | foo/bar-baz', function(hooks) {
   setupRenderingTest(hooks);
 
   // Replace this with your real tests.
-  test('it renders', async function(assert) {
+  test('it renders', async function(this: TestContext, assert) {
     this.set('inputValue', '1234');
 
     await render(hbs`{{foo/bar-baz inputValue}}`);

--- a/node-tests/fixtures/initializer-test/default.ts
+++ b/node-tests/fixtures/initializer-test/default.ts
@@ -4,21 +4,22 @@ import { run } from '@ember/runloop';
 import { initialize } from 'my-app/initializers/foo';
 import { module, test } from 'qunit';
 import destroyApp from '../../helpers/destroy-app';
+import { TestContext } from 'ember-test-helpers';
 
 module('Unit | Initializer | foo', {
-  beforeEach() {
+  beforeEach(this: TestContext) {
     run(() => {
       this.application = Application.create();
       this.application.deferReadiness();
     });
   },
-  afterEach() {
+  afterEach(this: TestContext) {
     destroyApp(this.application);
   }
 });
 
 // Replace this with your real tests.
-test('it works', function(assert) {
+test('it works', function(this: TestContext, assert) {
   initialize(this.application);
 
   // you would normally confirm the results of the initializer here

--- a/node-tests/fixtures/initializer-test/dummy.ts
+++ b/node-tests/fixtures/initializer-test/dummy.ts
@@ -4,21 +4,22 @@ import { run } from '@ember/runloop';
 import { initialize } from 'dummy/initializers/foo';
 import { module, test } from 'qunit';
 import destroyApp from '../../helpers/destroy-app';
+import { TestContext } from 'ember-test-helpers';
 
 module('Unit | Initializer | foo', {
-  beforeEach() {
+  beforeEach(this: TestContext) {
     run(() => {
       this.application = Application.create();
       this.application.deferReadiness();
     });
   },
-  afterEach() {
+  afterEach(this: TestContext) {
     destroyApp(this.application);
   }
 });
 
 // Replace this with your real tests.
-test('it works', function(assert) {
+test('it works', function(this: TestContext, assert) {
   initialize(this.application);
 
   // you would normally confirm the results of the initializer here

--- a/node-tests/fixtures/initializer-test/rfc232.ts
+++ b/node-tests/fixtures/initializer-test/rfc232.ts
@@ -4,11 +4,12 @@ import { initialize } from 'my-app/initializers/foo';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import destroyApp from '../../helpers/destroy-app';
+import { TestContext } from 'ember-test-helpers';
 
 module('Unit | Initializer | foo', function(hooks) {
   setupTest(hooks);
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function(this: TestContext) {
     this.TestApplication = Application.extend();
     this.TestApplication.initializer({
       name: 'initializer under test',
@@ -18,12 +19,12 @@ module('Unit | Initializer | foo', function(hooks) {
     this.application = this.TestApplication.create({ autoboot: false });
   });
 
-  hooks.afterEach(function() {
+  hooks.afterEach(function(this: TestContext) {
     destroyApp(this.application);
   });
 
   // Replace this with your real tests.
-  test('it works', async function(assert) {
+  test('it works', async function(this: TestContext, assert) {
     await this.application.boot();
 
     assert.ok(true);

--- a/node-tests/fixtures/instance-initializer-test/default.ts
+++ b/node-tests/fixtures/instance-initializer-test/default.ts
@@ -3,22 +3,23 @@ import { run } from '@ember/runloop';
 import { initialize } from 'my-app/instance-initializers/foo';
 import { module, test } from 'qunit';
 import destroyApp from '../../helpers/destroy-app';
+import { TestContext } from 'ember-test-helpers';
 
 module('Unit | Instance Initializer | foo', {
-  beforeEach() {
+  beforeEach(this: TestContext) {
     run(() => {
       this.application = Application.create();
       this.appInstance = this.application.buildInstance();
     });
   },
-  afterEach() {
+  afterEach(this: TestContext) {
     run(this.appInstance, 'destroy');
     destroyApp(this.application);
   }
 });
 
 // Replace this with your real tests.
-test('it works', function(assert) {
+test('it works', function(this: TestContext, assert) {
   initialize(this.appInstance);
 
   // you would normally confirm the results of the initializer here

--- a/node-tests/fixtures/instance-initializer-test/dummy.ts
+++ b/node-tests/fixtures/instance-initializer-test/dummy.ts
@@ -3,22 +3,23 @@ import { run } from '@ember/runloop';
 import { initialize } from 'dummy/instance-initializers/foo';
 import { module, test } from 'qunit';
 import destroyApp from '../../helpers/destroy-app';
+import { TestContext } from 'ember-test-helpers';
 
 module('Unit | Instance Initializer | foo', {
-  beforeEach() {
+  beforeEach(this: TestContext) {
     run(() => {
       this.application = Application.create();
       this.appInstance = this.application.buildInstance();
     });
   },
-  afterEach() {
+  afterEach(this: TestContext) {
     run(this.appInstance, 'destroy');
     destroyApp(this.application);
   }
 });
 
 // Replace this with your real tests.
-test('it works', function(assert) {
+test('it works', function(this: TestContext, assert) {
   initialize(this.appInstance);
 
   // you would normally confirm the results of the initializer here

--- a/node-tests/fixtures/instance-initializer-test/rfc232.ts
+++ b/node-tests/fixtures/instance-initializer-test/rfc232.ts
@@ -4,11 +4,12 @@ import { initialize } from 'my-app/instance-initializers/foo';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import destroyApp from '../../helpers/destroy-app';
+import { TestContext } from 'ember-test-helpers';
 
 module('Unit | Instance Initializer | foo', function(hooks) {
   setupTest(hooks);
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function(this: TestContext) {
     this.TestApplication = Application.extend();
     this.TestApplication.instanceInitializer({
       name: 'initializer under test',
@@ -17,13 +18,13 @@ module('Unit | Instance Initializer | foo', function(hooks) {
     this.application = this.TestApplication.create({ autoboot: false });
     this.instance = this.application.buildInstance();
   });
-  hooks.afterEach(function() {
+  hooks.afterEach(function(this: TestContext) {
     destroyApp(this.application);
     destroyApp(this.instance);
   });
 
   // Replace this with your real tests.
-  test('it works', async function(assert) {
+  test('it works', async function(this: TestContext, assert) {
     await this.instance.boot();
 
     assert.ok(true);

--- a/node-tests/fixtures/model-test/comment-default.ts
+++ b/node-tests/fixtures/model-test/comment-default.ts
@@ -1,11 +1,12 @@
 import { moduleForModel, test } from 'ember-qunit';
+import { TestContext } from 'ember-test-helpers';
 
 moduleForModel('comment', 'Unit | Model | comment', {
   // Specify the other units that are required for this test.
   needs: ['model:post', 'model:user']
 });
 
-test('it exists', function(assert) {
+test('it exists', function(this: TestContext, assert) {
   let model = this.subject();
   // let store = this.store();
   assert.ok(!!model);

--- a/node-tests/fixtures/model-test/foo-default.ts
+++ b/node-tests/fixtures/model-test/foo-default.ts
@@ -1,11 +1,12 @@
 import { moduleForModel, test } from 'ember-qunit';
+import { TestContext } from 'ember-test-helpers';
 
 moduleForModel('foo', 'Unit | Model | foo', {
   // Specify the other units that are required for this test.
   needs: []
 });
 
-test('it exists', function(assert) {
+test('it exists', function(this: TestContext, assert) {
   let model = this.subject();
   // let store = this.store();
   assert.ok(!!model);

--- a/node-tests/fixtures/model-test/foo-mocha-0.12.ts
+++ b/node-tests/fixtures/model-test/foo-mocha-0.12.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupModelTest } from 'ember-mocha';
+import { TestContext } from 'ember-test-helpers';
 
 describe('Unit | Model | foo', function() {
   setupModelTest('foo', {
@@ -9,7 +10,7 @@ describe('Unit | Model | foo', function() {
   });
 
   // Replace this with your real tests.
-  it('exists', function() {
+  it('exists', function(this: TestContext) {
     let model = this.subject();
     // var store = this.store();
     expect(model).to.be.ok;

--- a/node-tests/fixtures/model-test/post-default.ts
+++ b/node-tests/fixtures/model-test/post-default.ts
@@ -1,11 +1,12 @@
 import { moduleForModel, test } from 'ember-qunit';
+import { TestContext } from 'ember-test-helpers';
 
 moduleForModel('post', 'Unit | Model | post', {
   // Specify the other units that are required for this test.
   needs: ['model:comment']
 });
 
-test('it exists', function(assert) {
+test('it exists', function(this: TestContext, assert) {
   let model = this.subject();
   // let store = this.store();
   assert.ok(!!model);

--- a/node-tests/fixtures/model-test/rfc232.ts
+++ b/node-tests/fixtures/model-test/rfc232.ts
@@ -1,12 +1,13 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { run } from '@ember/runloop';
+import { TestContext } from 'ember-test-helpers';
 
 module('Unit | Model | foo', function(hooks) {
   setupTest(hooks);
 
   // Replace this with your real tests.
-  test('it exists', function(assert) {
+  test('it exists', function(this: TestContext, assert) {
     let store = this.owner.lookup('service:store');
     let model = run(() => store.createRecord('foo', {}));
     assert.ok(model);

--- a/node-tests/fixtures/route-test/default.ts
+++ b/node-tests/fixtures/route-test/default.ts
@@ -1,11 +1,12 @@
 import { moduleFor, test } from 'ember-qunit';
+import { TestContext } from 'ember-test-helpers';
 
 moduleFor('route:foo', 'Unit | Route | foo', {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
 });
 
-test('it exists', function(assert) {
+test('it exists', function(this: TestContext, assert) {
   let route = this.subject();
   assert.ok(route);
 });

--- a/node-tests/fixtures/route-test/mocha-0.12.ts
+++ b/node-tests/fixtures/route-test/mocha-0.12.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
+import { TestContext } from 'ember-test-helpers';
 
 describe('Unit | Route | foo', function() {
   setupTest('route:foo', {
@@ -8,7 +9,7 @@ describe('Unit | Route | foo', function() {
     // needs: ['controller:foo']
   });
 
-  it('exists', function() {
+  it('exists', function(this: TestContext) {
     let route = this.subject();
     expect(route).to.be.ok;
   });

--- a/node-tests/fixtures/route-test/mocha.ts
+++ b/node-tests/fixtures/route-test/mocha.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import { describeModule, it } from 'ember-mocha';
+import { TestContext } from 'ember-test-helpers';
 
 describeModule('route:foo', 'Unit | Route | foo',
   {
@@ -7,7 +8,7 @@ describeModule('route:foo', 'Unit | Route | foo',
     // needs: ['controller:foo']
   },
   function() {
-    it('exists', function() {
+    it('exists', function(this: TestContext) {
       let route = this.subject();
       expect(route).to.be.ok;
     });

--- a/node-tests/fixtures/route-test/rfc232.ts
+++ b/node-tests/fixtures/route-test/rfc232.ts
@@ -1,10 +1,11 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import { TestContext } from 'ember-test-helpers';
 
 module('Unit | Route | foo', function(hooks) {
   setupTest(hooks);
 
-  test('it exists', function(assert) {
+  test('it exists', function(this: TestContext, assert) {
     let route = this.owner.lookup('route:foo');
     assert.ok(route);
   });

--- a/node-tests/fixtures/serializer-test/application-default.ts
+++ b/node-tests/fixtures/serializer-test/application-default.ts
@@ -1,4 +1,5 @@
 import { moduleForModel, test } from 'ember-qunit';
+import { TestContext } from 'ember-test-helpers';
 
 moduleForModel('application', 'Unit | Serializer | application', {
   // Specify the other units that are required for this test.
@@ -6,7 +7,7 @@ moduleForModel('application', 'Unit | Serializer | application', {
 });
 
 // Replace this with your real tests.
-test('it serializes records', function(assert) {
+test('it serializes records', function(this: TestContext, assert) {
   let record = this.subject();
 
   let serializedRecord = record.serialize();

--- a/node-tests/fixtures/serializer-test/foo-default.ts
+++ b/node-tests/fixtures/serializer-test/foo-default.ts
@@ -1,4 +1,5 @@
 import { moduleForModel, test } from 'ember-qunit';
+import { TestContext } from 'ember-test-helpers';
 
 moduleForModel('foo', 'Unit | Serializer | foo', {
   // Specify the other units that are required for this test.
@@ -6,7 +7,7 @@ moduleForModel('foo', 'Unit | Serializer | foo', {
 });
 
 // Replace this with your real tests.
-test('it serializes records', function(assert) {
+test('it serializes records', function(this: TestContext, assert) {
   let record = this.subject();
 
   let serializedRecord = record.serialize();

--- a/node-tests/fixtures/serializer-test/foo-mocha-0.12.ts
+++ b/node-tests/fixtures/serializer-test/foo-mocha-0.12.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupModelTest } from 'ember-mocha';
+import { TestContext } from 'ember-test-helpers';
 
 describe('Unit | Serializer | foo', function() {
   setupModelTest('foo', {
@@ -9,7 +10,7 @@ describe('Unit | Serializer | foo', function() {
   });
 
   // Replace this with your real tests.
-  it('serializes records', function() {
+  it('serializes records', function(this: TestContext) {
     let record = this.subject();
 
     let serializedRecord = record.serialize();

--- a/node-tests/fixtures/serializer-test/rfc232.ts
+++ b/node-tests/fixtures/serializer-test/rfc232.ts
@@ -1,19 +1,20 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { run } from '@ember/runloop';
+import { TestContext } from 'ember-test-helpers';
 
 module('Unit | Serializer | foo', function(hooks) {
   setupTest(hooks);
 
   // Replace this with your real tests.
-  test('it exists', function(assert) {
+  test('it exists', function(this: TestContext, assert) {
     let store = this.owner.lookup('service:store');
     let serializer = store.serializerFor('foo');
 
     assert.ok(serializer);
   });
 
-  test('it serializes records', function(assert) {
+  test('it serializes records', function(this: TestContext, assert) {
     let store = this.owner.lookup('service:store');
     let record = run(() => store.createRecord('foo', {}));
 

--- a/node-tests/fixtures/service-test/default.ts
+++ b/node-tests/fixtures/service-test/default.ts
@@ -1,4 +1,5 @@
 import { moduleFor, test } from 'ember-qunit';
+import { TestContext } from 'ember-test-helpers';
 
 moduleFor('service:foo', 'Unit | Service | foo', {
   // Specify the other units that are required for this test.
@@ -6,7 +7,7 @@ moduleFor('service:foo', 'Unit | Service | foo', {
 });
 
 // Replace this with your real tests.
-test('it exists', function(assert) {
+test('it exists', function(this: TestContext, assert) {
   let service = this.subject();
   assert.ok(service);
 });

--- a/node-tests/fixtures/service-test/mocha-0.12.ts
+++ b/node-tests/fixtures/service-test/mocha-0.12.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
+import { TestContext } from 'ember-test-helpers';
 
 describe('Unit | Service | foo', function() {
   setupTest('service:foo', {
@@ -9,7 +10,7 @@ describe('Unit | Service | foo', function() {
   });
 
   // Replace this with your real tests.
-  it('exists', function() {
+  it('exists', function(this: TestContext) {
     let service = this.subject();
     expect(service).to.be.ok;
   });

--- a/node-tests/fixtures/service-test/mocha.ts
+++ b/node-tests/fixtures/service-test/mocha.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import { describeModule, it } from 'ember-mocha';
+import { TestContext } from 'ember-test-helpers';
 
 describeModule('service:foo', 'Unit | Service | foo',
   {
@@ -8,7 +9,7 @@ describeModule('service:foo', 'Unit | Service | foo',
   },
   function() {
     // Replace this with your real tests.
-    it('exists', function() {
+    it('exists', function(this: TestContext) {
       let service = this.subject();
       expect(service).to.be.ok;
     });

--- a/node-tests/fixtures/service-test/rfc232.ts
+++ b/node-tests/fixtures/service-test/rfc232.ts
@@ -1,11 +1,12 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import { TestContext } from 'ember-test-helpers';
 
 module('Unit | Service | foo', function(hooks) {
   setupTest(hooks);
 
   // Replace this with your real tests.
-  test('it exists', function(assert) {
+  test('it exists', function(this: TestContext, assert) {
     let service = this.owner.lookup('service:foo');
     assert.ok(service);
   });

--- a/node-tests/fixtures/transform-test/default.ts
+++ b/node-tests/fixtures/transform-test/default.ts
@@ -1,4 +1,5 @@
 import { moduleFor, test } from 'ember-qunit';
+import { TestContext } from 'ember-test-helpers';
 
 moduleFor('transform:foo', 'Unit | Transform | foo', {
   // Specify the other units that are required for this test.
@@ -6,7 +7,7 @@ moduleFor('transform:foo', 'Unit | Transform | foo', {
 });
 
 // Replace this with your real tests.
-test('it exists', function(assert) {
+test('it exists', function(this: TestContext, assert) {
   let transform = this.subject();
   assert.ok(transform);
 });

--- a/node-tests/fixtures/transform-test/mocha-0.12.ts
+++ b/node-tests/fixtures/transform-test/mocha-0.12.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
+import { TestContext } from 'ember-test-helpers';
 
 describe('Unit | Transform | foo', function() {
   setupTest('transform:foo', {
@@ -9,7 +10,7 @@ describe('Unit | Transform | foo', function() {
   });
 
   // Replace this with your real tests.
-  it('exists', function() {
+  it('exists', function(this: TestContext) {
     let transform = this.subject();
     expect(transform).to.be.ok;
   });

--- a/node-tests/fixtures/transform-test/rfc232.ts
+++ b/node-tests/fixtures/transform-test/rfc232.ts
@@ -1,11 +1,12 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import { TestContext } from 'ember-test-helpers';
 
 module('transform:foo', 'Unit | Transform | foo', function(hooks) {
   setupTest(hooks);
 
   // Replace this with your real tests.
-  test('it exists', function(assert) {
+  test('it exists', function(this: TestContext, assert) {
     let transform = this.owner.lookup('transform:foo');
     assert.ok(transform);
   });


### PR DESCRIPTION
This will generate tests such that tsc doesn't complain about `this` being untyped when `noImplicitThis` is turned on.