### PR TITLE
Update addon generator to support sourcemaps.                                13:46:39

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Use TypeScript in your Ember 2.x and 3.x apps!
 * [Setup and Configuration](#setup-and-configuration)
   * [Ember Support](#ember-support)
   * [`tsconfig.json`](#tsconfigjson)
+  * [Sourcemaps](#sourcemaps)
 * [Using TypeScript with Ember effectively](#using-typescript-with-ember-effectively)
   * [Incremental adoption](#incremental-adoption)
   * [Install other types!](#install-other-types)
@@ -83,6 +84,20 @@ However, there are a few things worth noting if you're already familiar with Typ
 
 [blueprint]: https://github.com/typed-ember/ember-cli-typescript/blob/master/blueprints/ember-cli-typescript/files/tsconfig.json
 [broccoli]: http://broccolijs.com/
+
+### Sourcemaps
+
+To enable TypeScript sourcemaps, you'll need to add the corresponding configuration for Babel to your `ember-cli-build.js` file:
+
+```ts
+const app = new EmberApp(defaults, {
+  babel: {
+    sourceMaps: 'inline',
+  }
+}
+```
+
+(Note that this _will_ noticeably slow down your app rebuilds.)
 
 ## Using TypeScript with Ember effectively
 

--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ To enable TypeScript sourcemaps, you'll need to add the corresponding configurat
 const app = new EmberApp(defaults, {
   babel: {
     sourceMaps: 'inline',
-  }
-}
+  },
+});
 ```
 
 (Note that this _will_ noticeably slow down your app rebuilds.)

--- a/blueprints/ember-cli-typescript/files/tsconfig.json
+++ b/blueprints/ember-cli-typescript/files/tsconfig.json
@@ -7,7 +7,8 @@
     "noImplicitThis": true,
     "noEmitOnError": false,
     "noEmit": true,
-    "sourceMap": true,
+    "inlineSourceMap": true,
+    "inlineSources": true,
     "baseUrl": ".",
     "module": "es6",
     "paths": <%= pathsFor(dasherizedPackageName) %>

--- a/node-tests/blueprints/ember-cli-typescript-test.js
+++ b/node-tests/blueprints/ember-cli-typescript-test.js
@@ -37,6 +37,9 @@ describe('Acceptance: ember-cli-typescript generator', function() {
           '*': ['types/*'],
         });
 
+        expect(tsconfigJson.compilerOptions.inlineSourceMap).to.equal(true);
+        expect(tsconfigJson.compilerOptions.inlineSources).to.equal(true);
+
         expect(tsconfigJson.include).to.deep.equal(['app', 'tests']);
 
         const projectTypes = file('types/my-app/index.d.ts');


### PR DESCRIPTION
- Set the correct default in the `tsconfig.json` blueprint.
- Add a note in the README with details on how to enable support for sourcemaps in Ember CLI/Babel.

Resolves #129.