### PR TITLE
Test coverage for precompilation and tree merging

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,12 @@ module.exports = {
     }
   },
 
+  shouldIncludeChildAddon(addon) {
+    // For testing, we have dummy in-repo addons set up, but e-c-ts doesn't depend on them;
+    // its dummy app does. Otherwise we'd have a circular dependency.
+    return addon.name !== 'in-repo-a' && addon.name !== 'in-repo-b';
+  },
+
   setupPreprocessorRegistry(type, registry) {
     if (type !== 'parent') {
       return;

--- a/lib/commands/precompile.js
+++ b/lib/commands/precompile.js
@@ -2,7 +2,7 @@
 'use strict';
 
 const tmpdir = require('../utilities/tmpdir');
-const fs = require('fs');
+const fs = require('fs-extra');
 const path = require('path');
 const walkSync = require('walk-sync');
 const mkdirp = require('mkdirp');
@@ -23,7 +23,14 @@ module.exports = Command.extend({
     let manifestPath = options.manifestPath;
     let project = this.project;
     let outDir = `${tmpdir()}/e-c-ts-precompile-${process.pid}`;
-    let flags = ['--declaration', '--sourceMap', 'false'];
+
+    // prettier-ignore
+    let flags = [
+      '--declaration',
+      '--sourceMap', 'false',
+      '--inlineSourceMap', 'false',
+      '--inlineSources', 'false',
+    ];
 
     return compile({ project, outDir, flags }).then(() => {
       let output = [];
@@ -42,6 +49,7 @@ module.exports = Command.extend({
 
       mkdirp.sync(path.dirname(manifestPath));
       fs.writeFileSync(manifestPath, JSON.stringify(output.reverse()));
+      fs.remove(outDir);
     });
   },
 
@@ -71,7 +79,7 @@ module.exports = Command.extend({
 
     fs.writeFileSync(dest, fs.readFileSync(source));
     output.push(dest);
-  }
+  },
 });
 
 module.exports.PRECOMPILE_MANIFEST = PRECOMPILE_MANIFEST;

--- a/node-tests/commands/clean-test.js
+++ b/node-tests/commands/clean-test.js
@@ -22,8 +22,8 @@ describe('Acceptance: ts:clean command', function() {
     fs.ensureDirSync('tmp');
     fs.ensureDirSync('app');
     fs.ensureDirSync('addon');
-    fs.writeFileSync('app/test-file.ts', `export const testString: string = 'app';\n`);
-    fs.writeFileSync('addon/test-file.ts', `export const testString: string = 'addon';\n`);
+    fs.writeFileSync('app/test-file.ts', `export const testString: string = 'app';`);
+    fs.writeFileSync('addon/test-file.ts', `export const testString: string = 'addon';`);
 
     let before = walkSync(process.cwd());
     return ember(['ts:precompile'])

--- a/node-tests/commands/clean-test.js
+++ b/node-tests/commands/clean-test.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const fs = require('fs-extra');
+const walkSync = require('walk-sync');
+
+const ember = require('ember-cli-blueprint-test-helpers/lib/helpers/ember');
+const blueprintHelpers = require('ember-cli-blueprint-test-helpers/helpers');
+const setupTestHooks = blueprintHelpers.setupTestHooks;
+const emberNew = blueprintHelpers.emberNew;
+
+const chai = require('ember-cli-blueprint-test-helpers/chai');
+const expect = chai.expect;
+
+describe('Acceptance: ts:clean command', function() {
+  setupTestHooks(this);
+
+  beforeEach(function() {
+    return emberNew({ target: 'addon' }).then(() => ember(['generate', 'ember-cli-typescript']));
+  });
+
+  it('removes all generated files', function() {
+    fs.ensureDirSync('tmp');
+    fs.ensureDirSync('app');
+    fs.ensureDirSync('addon');
+    fs.writeFileSync('app/test-file.ts', `export const testString: string = 'app';\n`);
+    fs.writeFileSync('addon/test-file.ts', `export const testString: string = 'addon';\n`);
+
+    let before = walkSync(process.cwd());
+    return ember(['ts:precompile'])
+      .then(() => ember(['ts:clean']))
+      .then(() => {
+        let after = walkSync(process.cwd());
+        expect(after).to.deep.equal(before);
+      });
+  });
+});

--- a/node-tests/commands/precompile-test.js
+++ b/node-tests/commands/precompile-test.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const fs = require('fs-extra');
+
+const ember = require('ember-cli-blueprint-test-helpers/lib/helpers/ember');
+const blueprintHelpers = require('ember-cli-blueprint-test-helpers/helpers');
+const setupTestHooks = blueprintHelpers.setupTestHooks;
+const emberNew = blueprintHelpers.emberNew;
+
+const chai = require('ember-cli-blueprint-test-helpers/chai');
+const expect = chai.expect;
+const file = chai.file;
+
+describe('Acceptance: ts:precompile command', function() {
+  setupTestHooks(this);
+
+  beforeEach(function() {
+    return emberNew({ target: 'addon' }).then(() => ember(['generate', 'ember-cli-typescript']));
+  });
+
+  it('generates .js and .d.ts files from the addon tree', function() {
+    fs.ensureDirSync('addon');
+    fs.writeFileSync('addon/test-file.ts', `export const testString: string = 'hello';\n`);
+
+    return ember(['ts:precompile'])
+      .then(() => {
+        let declaration = file('test-file.d.ts');
+        expect(declaration).to.exist;
+        expect(declaration.content).to.equal(`export declare const testString: string;\n`);
+
+        let transpiled = file('addon/test-file.js');
+        expect(transpiled).to.exist;
+        expect(transpiled.content).to.equal(`export const testString = 'hello';\n`);
+      });
+  });
+
+  it('generates .js files only from the app tree', function() {
+    fs.ensureDirSync('app');
+    fs.writeFileSync('app/test-file.ts', `export const testString: string = 'hello';\n`);
+
+    return ember(['ts:precompile']).then(() => {
+      let declaration = file('test-file.d.ts');
+      expect(declaration).not.to.exist;
+
+      let transpiled = file('app/test-file.js');
+      expect(transpiled).to.exist;
+      expect(transpiled.content.split('\n')[0]).to.equal(`export const testString = 'hello';`);
+    });
+  });
+});

--- a/node-tests/commands/precompile-test.js
+++ b/node-tests/commands/precompile-test.js
@@ -20,23 +20,23 @@ describe('Acceptance: ts:precompile command', function() {
 
   it('generates .js and .d.ts files from the addon tree', function() {
     fs.ensureDirSync('addon');
-    fs.writeFileSync('addon/test-file.ts', `export const testString: string = 'hello';\n`);
+    fs.writeFileSync('addon/test-file.ts', `export const testString: string = 'hello';`);
 
     return ember(['ts:precompile'])
       .then(() => {
         let declaration = file('test-file.d.ts');
         expect(declaration).to.exist;
-        expect(declaration.content).to.equal(`export declare const testString: string;\n`);
+        expect(declaration.content.trim()).to.equal(`export declare const testString: string;`);
 
         let transpiled = file('addon/test-file.js');
         expect(transpiled).to.exist;
-        expect(transpiled.content).to.equal(`export const testString = 'hello';\n`);
+        expect(transpiled.content.trim()).to.equal(`export const testString = 'hello';`);
       });
   });
 
   it('generates .js files only from the app tree', function() {
     fs.ensureDirSync('app');
-    fs.writeFileSync('app/test-file.ts', `export const testString: string = 'hello';\n`);
+    fs.writeFileSync('app/test-file.ts', `export const testString: string = 'hello';`);
 
     return ember(['ts:precompile']).then(() => {
       let declaration = file('test-file.d.ts');
@@ -44,7 +44,7 @@ describe('Acceptance: ts:precompile command', function() {
 
       let transpiled = file('app/test-file.js');
       expect(transpiled).to.exist;
-      expect(transpiled.content.split('\n')[0]).to.equal(`export const testString = 'hello';`);
+      expect(transpiled.content.trim()).to.equal(`export const testString = 'hello';`);
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "walk-sync": "^0.3.2"
   },
   "devDependencies": {
-    "@types/ember": "2.8.8",
+    "@types/ember": "2.8.13",
     "@types/ember-qunit": "^3.0.1",
     "@types/node": "*",
     "@types/qunit": "^2.0.31",
@@ -90,6 +90,9 @@
     "loader.js": "^4.2.3",
     "mocha": "^5.0.0",
     "typescript": "^2.7.2"
+  },
+  "resolutions": {
+    "@types/ember": "2.8.13",
   },
   "peerDependencies": {
     "typescript": "^2.4.2"

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "typescript": "^2.7.2"
   },
   "resolutions": {
-    "@types/ember": "2.8.13",
+    "@types/ember": "2.8.13"
   },
   "peerDependencies": {
     "typescript": "^2.4.2"

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "ember-router-generator": "^1.2.3",
     "execa": "^0.9.0",
     "exists-sync": "^0.0.4",
+    "fs-extra": "^5.0.0",
     "inflection": "^1.12.0",
     "mkdirp": "^0.5.1",
     "resolve": "^1.5.0",
@@ -59,7 +60,9 @@
   },
   "devDependencies": {
     "@types/ember": "2.8.8",
+    "@types/ember-qunit": "^3.0.1",
     "@types/node": "*",
+    "@types/qunit": "^2.0.31",
     "broccoli-asset-rev": "^2.6.0",
     "ember-cli": "~2.18.2",
     "ember-cli-app-version": "^3.1.3",
@@ -84,10 +87,9 @@
     "eslint": "^4.17.0",
     "eslint-plugin-ember": "^5.0.3",
     "eslint-plugin-node": "^6.0.0",
-    "fs-extra": "^5.0.0",
     "loader.js": "^4.2.3",
     "mocha": "^5.0.0",
-    "typescript": "^2.7.1"
+    "typescript": "^2.7.2"
   },
   "peerDependencies": {
     "typescript": "^2.4.2"
@@ -99,6 +101,10 @@
     "configPath": "tests/dummy/config",
     "before": [
       "ember-cli-babel"
+    ],
+    "paths": [
+      "tests/dummy/lib/in-repo-a",
+      "tests/dummy/lib/in-repo-b"
     ]
   },
   "prettier": {

--- a/tests/dummy/app/shadowed-file.ts
+++ b/tests/dummy/app/shadowed-file.ts
@@ -1,0 +1,5 @@
+// This file should win out over `shadowed-file.ts` and `shadowed-file.js`
+// in our two in-repo addons.
+const value: string = 'dummy/shadowed-file';
+
+export default value;

--- a/tests/dummy/lib/in-repo-a/addon/test-file.ts
+++ b/tests/dummy/lib/in-repo-a/addon/test-file.ts
@@ -1,0 +1,4 @@
+// This should wind up in the addon tree
+const value: string = 'in-repo-a/test-file';
+
+export default value;

--- a/tests/dummy/lib/in-repo-a/app/a.ts
+++ b/tests/dummy/lib/in-repo-a/app/a.ts
@@ -1,0 +1,4 @@
+// This should wind up in the app tree
+const value: string = 'dummy/a';
+
+export default value;

--- a/tests/dummy/lib/in-repo-a/app/shadowed-file.ts
+++ b/tests/dummy/lib/in-repo-a/app/shadowed-file.ts
@@ -1,0 +1,4 @@
+// This should be shadowed by the dummy app's own `shadowed-file.ts`
+const value: string = 'bad';
+
+export default value;

--- a/tests/dummy/lib/in-repo-a/index.js
+++ b/tests/dummy/lib/in-repo-a/index.js
@@ -1,0 +1,10 @@
+/* eslint-env node */
+'use strict';
+
+module.exports = {
+  name: 'in-repo-a',
+
+  isDevelopingAddon() {
+    return true;
+  }
+};

--- a/tests/dummy/lib/in-repo-a/package.json
+++ b/tests/dummy/lib/in-repo-a/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "in-repo-a",
+  "keywords": [
+    "ember-addon"
+  ],
+  "dependencies": {
+    "ember-cli-babel": "*"
+  },
+  "devDependencies": {
+    "ember-cli-typescript": "*"
+  }
+}

--- a/tests/dummy/lib/in-repo-b/addon/test-file.ts
+++ b/tests/dummy/lib/in-repo-b/addon/test-file.ts
@@ -1,0 +1,4 @@
+// This should wind up in the addon tree
+const value: string = 'in-repo-b/test-file';
+
+export default value;

--- a/tests/dummy/lib/in-repo-b/app/b.ts
+++ b/tests/dummy/lib/in-repo-b/app/b.ts
@@ -1,0 +1,4 @@
+// This should wind up in the app tree
+const value: string = 'dummy/b';
+
+export default value;

--- a/tests/dummy/lib/in-repo-b/app/shadowed-file.js
+++ b/tests/dummy/lib/in-repo-b/app/shadowed-file.js
@@ -1,0 +1,4 @@
+// This should be shadowed by the dummy app's own `sahdowed-file.ts`
+const value = 'bad';
+
+export default value;

--- a/tests/dummy/lib/in-repo-b/index.js
+++ b/tests/dummy/lib/in-repo-b/index.js
@@ -1,0 +1,10 @@
+/* eslint-env node */
+'use strict';
+
+module.exports = {
+  name: 'in-repo-b',
+
+  isDevelopingAddon() {
+    return true;
+  }
+};

--- a/tests/dummy/lib/in-repo-b/package.json
+++ b/tests/dummy/lib/in-repo-b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "in-repo-b",
+  "keywords": [
+    "ember-addon"
+  ],
+  "dependencies": {
+    "ember-cli-babel": "*"
+  },
+  "devDependencies": {
+    "ember-cli-typescript": "*"
+  }
+}

--- a/tests/unit/build-test.ts
+++ b/tests/unit/build-test.ts
@@ -1,0 +1,23 @@
+import { module, test } from 'qunit';
+
+import addonFileA from 'in-repo-a/test-file';
+import addonFileB from 'in-repo-b/test-file';
+import fileA from 'dummy/a';
+import fileB from 'dummy/b';
+import shadowedFile from 'dummy/shadowed-file';
+
+module('Unit | Build');
+
+test('in-repo addons\' addon trees wind up in the right place', function(assert) {
+  assert.equal(addonFileA, 'in-repo-a/test-file');
+  assert.equal(addonFileB, 'in-repo-b/test-file');
+});
+
+test('in-repo addons\' app trees wind up in the right place', function(assert) {
+  assert.equal(fileA, 'dummy/a');
+  assert.equal(fileB, 'dummy/b');
+});
+
+test('app files aren\'t shadowed by addons\' app tree files', function(assert) {
+  assert.equal(shadowedFile, 'dummy/shadowed-file');
+});

--- a/tests/unit/dummy.ts
+++ b/tests/unit/dummy.ts
@@ -1,4 +1,0 @@
-/*
- Need at least one ts file to avoid error
- "No inputs were found in config file 'tsconfig.json'."
-*/

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,9 @@
     "baseUrl": ".",
     "paths": {
       "dummy/tests/*": ["tests/*"],
-      "dummy/*": ["tests/dummy/app/*"]
+      "dummy/*": ["tests/dummy/app/*", "tests/dummy/lib/in-repo-a/app/*", "tests/dummy/lib/in-repo-b/app/*"],
+      "in-repo-a/*": ["tests/dummy/lib/in-repo-a/addon/*"],
+      "in-repo-b/*": ["tests/dummy/lib/in-repo-b/addon/*"]
     }
   },
   "include": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,7 +20,23 @@
   dependencies:
     "@glimmer/di" "^0.2.0"
 
-"@types/ember@2.8.8":
+"@types/ember-qunit@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/ember-qunit/-/ember-qunit-3.0.1.tgz#ddf7f25e75eb0a91f18e159369876bf02496dd38"
+  dependencies:
+    "@types/ember" "*"
+    "@types/ember-test-helpers" "*"
+
+"@types/ember-test-helpers@*":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@types/ember-test-helpers/-/ember-test-helpers-0.7.1.tgz#14b9f132e9c60c2dfaf7a10ace937bfb7157fb26"
+  dependencies:
+    "@types/ember" "*"
+    "@types/htmlbars-inline-precompile" "*"
+    "@types/jquery" "*"
+    "@types/rsvp" "*"
+
+"@types/ember@*", "@types/ember@2.8.8":
   version "2.8.8"
   resolved "https://registry.yarnpkg.com/@types/ember/-/ember-2.8.8.tgz#a3621385cb91a2ff4a9e2cd2a5f0f7c33b9f5d5d"
   dependencies:
@@ -32,6 +48,10 @@
   version "4.0.35"
   resolved "https://registry.yarnpkg.com/@types/handlebars/-/handlebars-4.0.35.tgz#409eb97a3ad6970daba4d586cb6afe3f5e082c01"
 
+"@types/htmlbars-inline-precompile@*":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/htmlbars-inline-precompile/-/htmlbars-inline-precompile-1.0.0.tgz#4c283da1a7e303b269de3c6aa953acc8d8736949"
+
 "@types/jquery@*":
   version "3.2.10"
   resolved "https://registry.yarnpkg.com/@types/jquery/-/jquery-3.2.10.tgz#0e3da7ad6481a1cdf48af39ff00a990afeb8018b"
@@ -39,6 +59,10 @@
 "@types/node@*":
   version "8.5.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.5.1.tgz#4ec3020bcdfe2abffeef9ba3fbf26fca097514b5"
+
+"@types/qunit@^2.0.31":
+  version "2.0.31"
+  resolved "https://registry.yarnpkg.com/@types/qunit/-/qunit-2.0.31.tgz#a53e2cf635262c8bf46a71a137d8c7970dde9562"
 
 "@types/rsvp@*":
   version "4.0.0"
@@ -6794,9 +6818,9 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@^2.7.1:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.1.tgz#bb3682c2c791ac90e7c6210b26478a8da085c359"
+typescript@^2.7.2:
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
 
 uc.micro@^1.0.1, uc.micro@^1.0.3:
   version "1.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -36,9 +36,9 @@
     "@types/jquery" "*"
     "@types/rsvp" "*"
 
-"@types/ember@*", "@types/ember@2.8.8":
-  version "2.8.8"
-  resolved "https://registry.yarnpkg.com/@types/ember/-/ember-2.8.8.tgz#a3621385cb91a2ff4a9e2cd2a5f0f7c33b9f5d5d"
+"@types/ember@*", "@types/ember@2.8.13":
+  version "2.8.13"
+  resolved "https://registry.yarnpkg.com/@types/ember/-/ember-2.8.13.tgz#4577bb9684ef5b75b49c181dc56075a94e8002c8"
   dependencies:
     "@types/handlebars" "*"
     "@types/jquery" "*"


### PR DESCRIPTION
This adds test coverage for the `ts:precompile` and `ts:clean` commands (and makes `precompile` clean up after itself).

It also introduces a pair of in-repo-addons to the dummy app and ensures that files in their `app` and `addon` trees will be built and are importable from the correct places.