### PR TITLE
Acknowledge that we care about .ts files

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ module.exports = {
 
     registry.add('js', {
       name: 'ember-cli-typescript',
+      ext: 'ts',
       toTree: (original, inputPath, outputPath) => {
         if (!this.compiler || inputPath !== '/') {
           return original;


### PR DESCRIPTION
To support ember-cli-code-coverage, which queries the preprocessor registry to determine which file extensions it should care about, we need to advertise the fact that `.ts` files count as JS sources.