### PR TITLE
Ensure TS blueprints are used. Fixes #9.

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,10 @@
     "before": [
       "ember-cli-babel"
     ],
+    "after": [
+      "ember-source",
+      "ember-data"
+    ],
     "paths": [
       "tests/dummy/lib/in-repo-a",
       "tests/dummy/lib/in-repo-b"


### PR DESCRIPTION
Experimented with this locally. Making us be before `ember-source` and `ember-data` consistently resulted in JS files being generated, and putting us after gets us TS, so it looks like `after` is the ticket.