### PR TITLE
Skip everything if only .md files have changed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,14 +31,17 @@ matrix:
   allow_failures:
     - env: EMBER_TRY_SCENARIO=ember-canary
 
+before_install:
+  - bash ./is_md_only.sh && MD_ONLY=true && echo "Only .md files have changed!" || test true
+
 install:
-  - yarn install --no-lockfile
+  - test $MD_ONLY && echo "Skipped!" || yarn install --no-lockfile
 
 script:
-  - yarn lint:js
+  - test $MD_ONLY && echo "Skipped!" || yarn lint:js
   # Usually, it's ok to finish the test scenario without reverting
   #  to the addon's original dependency state, skipping "cleanup".
-  - yarn ember try:one $EMBER_TRY_SCENARIO --skip-cleanup
+  - test $MD_ONLY && echo "Skipped!" || yarn ember try:one $EMBER_TRY_SCENARIO --skip-cleanup
 
 # We build PRs, but don't trigger separate builds for the PR from the branch.
 branches:

--- a/is_md_only.sh
+++ b/is_md_only.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+CHANGED_FILES=`git diff --name-only master...${TRAVIS_COMMIT}`
+
+[[ -z $CHANGED_FILES ]] && exit 1
+
+for CHANGED_FILE in $CHANGED_FILES; do
+  if ! [[ $CHANGED_FILE =~ .md$ ]]; then
+    exit 1
+  fi
+done


### PR DESCRIPTION
Skip all Travis `install` and `script` tasks if only .md files have changed.

[Sample build](https://travis-ci.org/jamescdavis/ember-cli-typescript/builds/345570960)