### PR TITLE
Generate functioning addon components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
+### Added
+
+* @ts-ignore component template import.
+
 ### Changed
 
 * Improve instructions for setting up [Linked Addons](README.md#linking-addons) and [In-repo Addons](README.md#in-repo-addons).
+
+### Fixed
+
+* Addon components need to manually set their layout property to the imported compiled template.
 
 ## [1.1.6] - 2018-02-23
 

--- a/blueprints/component/files/__root__/__path__/__name__.ts
+++ b/blueprints/component/files/__root__/__path__/__name__.ts
@@ -2,6 +2,6 @@ import Component from '@ember/component';
 <%= importTemplate %>
 export default class <%= classifiedModuleName %> extends Component.extend({
   // anything which *must* be merged to prototype here
-}) {
+}) {<%= contents %>
   // normal class body definition here
 };

--- a/blueprints/component/index.js
+++ b/blueprints/component/index.js
@@ -63,7 +63,7 @@ module.exports = {
           'templates/components/' + stringUtil.dasherize(options.entity.name);
       }
       importTemplate   = 'import layout from \'' + templatePath + '\';\n';
-      contents         = '\n  layout';
+      contents         = '\n  layout = layout;';
     }
 
     return {

--- a/blueprints/component/index.js
+++ b/blueprints/component/index.js
@@ -62,7 +62,7 @@ module.exports = {
         templatePath   = pathUtil.getRelativeParentPath(options.entity.name) +
           'templates/components/' + stringUtil.dasherize(options.entity.name);
       }
-      importTemplate   = 'import layout from \'' + templatePath + '\';\n';
+      importTemplate   = '// @ts-ignore: Ignore import of compiled template\nimport layout from \'' + templatePath + '\';\n';
       contents         = '\n  layout = layout;';
     }
 

--- a/node-tests/blueprints/component-test.js
+++ b/node-tests/blueprints/component-test.js
@@ -26,6 +26,8 @@ describe('Acceptance: ember generate and destroy component', function() {
     return emberNew({ target: 'addon' })
       .then(() => emberGenerateDestroy(args, (file) => {
         expect(file('addon/components/foo-bar.ts'))
+          .to.contain('// @ts-ignore: Ignore import of compiled template\nimport layout from \'../templates/components/foo-bar\';\n');
+        expect(file('addon/components/foo-bar.ts'))
           .to.contain('layout = layout;');
     }));
   });

--- a/node-tests/blueprints/component-test.js
+++ b/node-tests/blueprints/component-test.js
@@ -19,4 +19,14 @@ describe('Acceptance: ember generate and destroy component', function() {
         expect(file('app/components/foo-bar.ts')).to.contain('export default class FooBar extends Component.extend');
     }));
   });
+
+  it('addon component foo-bar', function() {
+    let args = ['component', 'foo-bar'];
+
+    return emberNew({ target: 'addon' })
+      .then(() => emberGenerateDestroy(args, (file) => {
+        expect(file('addon/components/foo-bar.ts'))
+          .to.contain('layout = layout;');
+    }));
+  });
 });


### PR DESCRIPTION
Components generated in an addon are not currently functional because they are missing the manual setting of their layout property to their compiled template.