### PR TITLE
Add -addon blueprints that generate .ts files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Added
 
 * @ts-ignore component template import.
+* -addon blueprints for all the things to generate .ts files in `app/` in an addon.
 
 ### Changed
 

--- a/blueprints/-addon-import.js
+++ b/blueprints/-addon-import.js
@@ -1,0 +1,44 @@
+'use strict';
+
+var stringUtil  = require('ember-cli-string-utils');
+var path        = require('path');
+var inflector   = require('inflection');
+
+module.exports = {
+  description: 'Generates an import wrapper.',
+
+  fileMapTokens: function() {
+    return {
+      __name__: function(options) {
+        return options.dasherizedModuleName;
+      },
+      __path__: function(options) {
+        return inflector.pluralize(options.locals.blueprintName);
+      },
+      __root__: function(options) {
+        if (options.inRepoAddon) {
+          return path.join('lib', options.inRepoAddon, 'app');
+        }
+        return 'app';
+      }
+    };
+  },
+
+  locals: function(options) {
+    var addonRawName       = options.inRepoAddon ? options.inRepoAddon : options.project.name();
+    var addonName          = stringUtil.dasherize(addonRawName);
+    var fileName           = stringUtil.dasherize(options.entity.name);
+    var blueprintName      = options.originBlueprintName;
+    var modulePathSegments = [addonName, inflector.pluralize(options.originBlueprintName), fileName];
+
+    if (blueprintName.match(/-addon/)) {
+      blueprintName = blueprintName.substr(0, blueprintName.indexOf('-addon'));
+      modulePathSegments = [addonName, inflector.pluralize(blueprintName), fileName];
+    }
+
+    return {
+      modulePath: modulePathSegments.join('/'),
+      blueprintName: blueprintName
+    };
+  }
+};

--- a/blueprints/component-addon/files/__root__/__path__/__name__.ts
+++ b/blueprints/component-addon/files/__root__/__path__/__name__.ts
@@ -1,0 +1,1 @@
+export { default } from '<%= modulePath %>';

--- a/blueprints/component-addon/index.js
+++ b/blueprints/component-addon/index.js
@@ -1,0 +1,56 @@
+/* eslint-env node */
+
+var stringUtil         = require('ember-cli-string-utils');
+var validComponentName = require('ember-cli-valid-component-name');
+var getPathOption      = require('ember-cli-get-component-path-option');
+var path               = require('path');
+var normalizeEntityName = require('ember-cli-normalize-entity-name');
+
+module.exports = {
+  description: 'Generates a component. Name must contain a hyphen.',
+
+  fileMapTokens: function() {
+    return {
+      __path__: function(options) {
+        if (options.pod) {
+          return path.join(options.podPath, options.locals.path, options.dasherizedModuleName);
+        }
+        return 'components';
+      },
+      __name__: function(options) {
+        if (options.pod) {
+          return 'component';
+        }
+        return options.dasherizedModuleName;
+      },
+      __root__: function(options) {
+        if (options.inRepoAddon) {
+          return path.join('lib', options.inRepoAddon, 'app');
+        }
+        return 'app';
+      }
+    };
+  },
+
+  normalizeEntityName: function(entityName) {
+    entityName = normalizeEntityName(entityName);
+
+    return validComponentName(entityName);
+  },
+
+  locals: function(options) {
+    var addonRawName   = options.inRepoAddon ? options.inRepoAddon : options.project.name();
+    var addonName      = stringUtil.dasherize(addonRawName);
+    var fileName       = stringUtil.dasherize(options.entity.name);
+    var importPathName       = [addonName, 'components', fileName].join('/');
+
+    if (options.pod) {
+      importPathName = [addonName, 'components', fileName, 'component'].join('/');
+    }
+
+    return {
+      modulePath: importPathName,
+      path: getPathOption(options)
+    };
+  }
+};

--- a/blueprints/helper-addon/files/__root__/__path__/__name__.ts
+++ b/blueprints/helper-addon/files/__root__/__path__/__name__.ts
@@ -1,0 +1,1 @@
+export { default, <%= camelizedModuleName %> } from '<%= modulePath %>';

--- a/blueprints/helper-addon/index.js
+++ b/blueprints/helper-addon/index.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('../-addon-import');

--- a/blueprints/initializer-addon/files/__root__/__path__/__name__.ts
+++ b/blueprints/initializer-addon/files/__root__/__path__/__name__.ts
@@ -1,0 +1,1 @@
+export { default, initialize } from '<%= modulePath %>';

--- a/blueprints/initializer-addon/index.js
+++ b/blueprints/initializer-addon/index.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('../-addon-import');

--- a/blueprints/instance-initializer-addon/files/__root__/__path__/__name__.ts
+++ b/blueprints/instance-initializer-addon/files/__root__/__path__/__name__.ts
@@ -1,0 +1,1 @@
+export { default, initialize } from '<%= modulePath %>';

--- a/blueprints/instance-initializer-addon/index.js
+++ b/blueprints/instance-initializer-addon/index.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('../-addon-import');

--- a/blueprints/route-addon/files/__root__/__path__/__name__.ts
+++ b/blueprints/route-addon/files/__root__/__path__/__name__.ts
@@ -1,0 +1,1 @@
+export { default } from '<%= routeModulePath %>';

--- a/blueprints/route-addon/files/__root__/__templatepath__/__templatename__.ts
+++ b/blueprints/route-addon/files/__root__/__templatepath__/__templatename__.ts
@@ -1,0 +1,1 @@
+export { default } from '<%= templateModulePath %>';

--- a/blueprints/route-addon/index.js
+++ b/blueprints/route-addon/index.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const path = require('path');
+const stringUtil = require('ember-cli-string-utils');
+const inflector = require('inflection');
+
+module.exports = {
+  description: 'Generates import wrappers for a route and its template.',
+
+  fileMapTokens: function() {
+    return {
+      __templatepath__: function(options) {
+        if (options.pod) {
+          return path.join(options.podPath, options.dasherizedModuleName);
+        }
+        return 'templates';
+      },
+      __templatename__: function(options) {
+        if (options.pod) {
+          return 'template';
+        }
+        return options.dasherizedModuleName;
+      },
+      __name__: function (options) {
+        if (options.pod) {
+          return 'route';
+        }
+
+        return options.dasherizedModuleName;
+      },
+      __path__: function(options) {
+        if (options.pod && options.hasPathToken) {
+          return path.join(options.podPath, options.dasherizedModuleName);
+        }
+
+        return 'routes';
+      },
+      __root__: function(options) {
+        if (options.inRepoAddon) {
+          return path.join('lib', options.inRepoAddon, 'app');
+        }
+
+        return 'app';
+      }
+    };
+  },
+
+  locals: function (options) {
+    let locals = {};
+    let addonRawName = options.inRepoAddon ? options.inRepoAddon : options.project.name();
+    let addonName = stringUtil.dasherize(addonRawName);
+    let fileName = stringUtil.dasherize(options.entity.name);
+
+    ['route', 'template'].forEach(function (blueprint) {
+      let pathName = [addonName, inflector.pluralize(blueprint), fileName].join('/');
+
+      if (options.pod) {
+        pathName = [addonName, fileName, blueprint].join('/');
+      }
+
+      locals[blueprint + 'ModulePath'] = pathName;
+    });
+
+    return locals;
+  }
+};

--- a/node-tests/blueprints/component-addon-test.js
+++ b/node-tests/blueprints/component-addon-test.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const blueprintHelpers = require('ember-cli-blueprint-test-helpers/helpers');
+const setupTestHooks = blueprintHelpers.setupTestHooks;
+const emberNew = blueprintHelpers.emberNew;
+const emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
+
+const chai = require('ember-cli-blueprint-test-helpers/chai');
+const expect = chai.expect;
+
+describe('Blueprint: component-addon', function() {
+  setupTestHooks(this);
+
+  describe('in addon', function() {
+    beforeEach(function() {
+      return emberNew({ target: 'addon' });
+    });
+
+    it('component-addon foo-bar', function() {
+      return emberGenerateDestroy(['component-addon', 'foo-bar'], _file => {
+        expect(_file('app/components/foo-bar.ts'))
+          .to.contain("export { default } from 'my-addon/components/foo-bar';");
+      });
+    });
+  });
+});

--- a/node-tests/blueprints/helper-addon-test.js
+++ b/node-tests/blueprints/helper-addon-test.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const blueprintHelpers = require('ember-cli-blueprint-test-helpers/helpers');
+const setupTestHooks = blueprintHelpers.setupTestHooks;
+const emberNew = blueprintHelpers.emberNew;
+const emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
+
+const chai = require('ember-cli-blueprint-test-helpers/chai');
+const expect = chai.expect;
+
+const fixture = require('../helpers/fixture');
+
+describe('Blueprint: helper-addon', function() {
+  setupTestHooks(this);
+
+  describe('in addon', function() {
+    beforeEach(function() {
+      return emberNew({ target: 'addon' });
+    });
+
+    it('helper-addon foo/bar-baz', function() {
+      return emberGenerateDestroy(['helper-addon', 'foo/bar-baz'], _file => {
+        expect(_file('app/helpers/foo/bar-baz.ts'))
+          .to.equal(fixture('helper-addon.ts'));
+      });
+    });
+
+    it('helper-addon foo/bar-baz --pod', function() {
+      return emberGenerateDestroy(['helper-addon', 'foo/bar-baz', '--pod'], _file => {
+        expect(_file('app/helpers/foo/bar-baz.ts'))
+          .to.equal(fixture('helper-addon.ts'));
+      });
+    });
+  });
+});

--- a/node-tests/blueprints/initializer-addon-test.js
+++ b/node-tests/blueprints/initializer-addon-test.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const blueprintHelpers = require('ember-cli-blueprint-test-helpers/helpers');
+const setupTestHooks = blueprintHelpers.setupTestHooks;
+const emberNew = blueprintHelpers.emberNew;
+const emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
+
+const chai = require('ember-cli-blueprint-test-helpers/chai');
+const expect = chai.expect;
+
+describe('Blueprint: initializer-addon', function() {
+  setupTestHooks(this);
+
+  describe('in addon', function() {
+    beforeEach(function() {
+      return emberNew({ target: 'addon' });
+    });
+
+    it('initializer-addon foo', function() {
+      return emberGenerateDestroy(['initializer-addon', 'foo'], _file => {
+        expect(_file('app/initializers/foo.ts'))
+          .to.contain("export { default, initialize } from 'my-addon/initializers/foo';");
+      });
+    });
+
+    it('initializer-addon foo --pod', function() {
+      return emberGenerateDestroy(['initializer-addon', 'foo', '--pod'], _file => {
+        expect(_file('app/initializers/foo.ts'))
+          .to.contain("export { default, initialize } from 'my-addon/initializers/foo';");
+      });
+    });
+  });
+});

--- a/node-tests/blueprints/instance-initializer-addon-test.js
+++ b/node-tests/blueprints/instance-initializer-addon-test.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const blueprintHelpers = require('ember-cli-blueprint-test-helpers/helpers');
+const setupTestHooks = blueprintHelpers.setupTestHooks;
+const emberNew = blueprintHelpers.emberNew;
+const emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
+
+const chai = require('ember-cli-blueprint-test-helpers/chai');
+const expect = chai.expect;
+
+describe('Blueprint: instance-initializer-addon', function() {
+  setupTestHooks(this);
+
+  describe('in addon', function() {
+    beforeEach(function() {
+      return emberNew({ target: 'addon' });
+    });
+
+    it('instance-initializer-addon foo', function() {
+      return emberGenerateDestroy(['instance-initializer-addon', 'foo'], _file => {
+        expect(_file('app/instance-initializers/foo.ts'))
+          .to.contain("export { default, initialize } from 'my-addon/instance-initializers/foo';");
+      });
+    });
+
+    it('instance-initializer-addon foo --pod', function() {
+      return emberGenerateDestroy(['instance-initializer-addon', 'foo', '--pod'], _file => {
+        expect(_file('app/instance-initializers/foo.ts'))
+          .to.contain("export { default, initialize } from 'my-addon/instance-initializers/foo';");
+      });
+    });
+  });
+});

--- a/node-tests/blueprints/route-addon-test.js
+++ b/node-tests/blueprints/route-addon-test.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const blueprintHelpers = require('ember-cli-blueprint-test-helpers/helpers');
+const setupTestHooks = blueprintHelpers.setupTestHooks;
+const emberNew = blueprintHelpers.emberNew;
+const emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
+
+const chai = require('ember-cli-blueprint-test-helpers/chai');
+const expect = chai.expect;
+
+describe('Blueprint: route-addon', function() {
+  setupTestHooks(this);
+
+  describe('in addon', function() {
+    beforeEach(function() {
+      return emberNew({ target: 'addon' });
+    });
+
+    it('route-addon foo', function() {
+      return emberGenerateDestroy(['route-addon', 'foo'], _file => {
+        expect(_file('app/routes/foo.ts'))
+          .to.contain("export { default } from 'my-addon/routes/foo';");
+
+        expect(_file('app/templates/foo.ts'))
+          .to.contain("export { default } from 'my-addon/templates/foo';");
+      });
+    });
+  });
+});

--- a/node-tests/fixtures/helper-addon.ts
+++ b/node-tests/fixtures/helper-addon.ts
@@ -1,0 +1,1 @@
+export { default, fooBarBaz } from 'my-addon/helpers/foo/bar-baz';


### PR DESCRIPTION
For full addon typescriptage.

Note: this includes https://github.com/emberjs/ember.js/pull/16293 because the -addon blueprints were broken for `helper`, `initializer`, and `instance-initializer` with `usePods: true`.