### PR TITLE
Updated types version on resolutions to work for e-c-ts 1.20

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,7 +498,7 @@ There are two options here, neither of them _great_:
 ```json
 {
   "resolutions": {
-    "**/@types/ember": "2.8.8"
+    "**/@types/ember": "2.8.15"
   }
 }
 ```


### PR DESCRIPTION
The instructions in the README for avoiding "multiple copies of the same type" warnings needed the version number of **/@types/ember bumped to 2.8.15 to match the proper version for the latest release. This will, of course, be a perennial headache to keep current, but at least this fixes it until the next update.