### PR TITLE
Ensure that ects is a dependency when generating in-repo addons

### DIFF
--- a/blueprints/in-repo-addon/files/lib/__name__/package.json
+++ b/blueprints/in-repo-addon/files/lib/__name__/package.json
@@ -2,5 +2,8 @@
   "name": "<%= dasherizedModuleName %>",
   "keywords": [
     "ember-addon"
-  ]
+  ],
+  "devDependencies": {
+    "ember-cli-typescript": "*"
+  }
 }

--- a/node-tests/blueprints/in-repo-addon-test.js
+++ b/node-tests/blueprints/in-repo-addon-test.js
@@ -42,6 +42,9 @@ describe('Acceptance: ember generate and destroy in-repo-addon', function() {
           "keywords": [
             "ember-addon",
           ],
+          "devDependencies": {
+            "ember-cli-typescript": "*"
+          }
         });
 
         expect(fs.readJsonSync('package.json')['ember-addon']).to.deep.equal({


### PR DESCRIPTION
The blueprint for in-repo addons doesn't add `ember-cli-typescript` as a dependency, so this prevents `.ts` from being merged into the `app` tree.

This PR just adds it to the blueprint