### PR TITLE
Pull out incremental-compiler state management

### DIFF
--- a/lib/commands/precompile.js
+++ b/lib/commands/precompile.js
@@ -6,7 +6,6 @@ const execa = require('execa');
 const fs = require('fs-extra');
 const path = require('path');
 const walkSync = require('walk-sync');
-const mkdirp = require('mkdirp');
 const Command = require('ember-cli/lib/models/command'); // eslint-disable-line node/no-unpublished-require
 
 const PRECOMPILE_MANIFEST = 'tmp/.ts-precompile-manifest';
@@ -37,7 +36,7 @@ module.exports = Command.extend({
     ];
 
     // Ensure the output directory is created even if no files are generated
-    mkdirp.sync(outDir);
+    fs.mkdirsSync(outDir);
 
     return execa('tsc', flags).then(() => {
       let output = [];
@@ -54,7 +53,7 @@ module.exports = Command.extend({
         }
       }
 
-      mkdirp.sync(path.dirname(manifestPath));
+      fs.mkdirsSync(path.dirname(manifestPath));
       fs.writeFileSync(manifestPath, JSON.stringify(output.reverse()));
       fs.remove(outDir);
     });

--- a/lib/incremental-typescript-compiler/compiler-state.js
+++ b/lib/incremental-typescript-compiler/compiler-state.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const debug = require('debug')('ember-cli-typescript:compiler-state');
+const RSVP = require('rsvp');
+
+/*
+ * This class captures the state of the Broccoli build and the TypeScript
+ * compilation process in terms of our concurrent juggling of the two.
+ * It maintains a `buildDeferred` object for the most recently started
+ * TS compilation, and it accepts notifications about changes in the state
+ * of the world framed as {broccoli,tsc}Did{Start,End} method calls.
+ */
+module.exports = class CompilerState {
+  constructor() {
+    this._buildingBroccoliNodes = 0;
+    this.tscDidStart();
+  }
+
+  broccoliDidStart() {
+    this._buildingBroccoliNodes++;
+    this._emitTransition('broccoliDidStart');
+  }
+
+  broccoliDidEnd() {
+    this._buildingBroccoliNodes--;
+    this._emitTransition('broccoliDidEnd');
+  }
+
+  tscDidStart() {
+    if (this.buildDeferred) {
+      this.buildDeferred.resolve();
+    }
+
+    this.buildDeferred = RSVP.defer();
+    this._tscBuilding = true;
+    this._pendingErrors = [];
+    this._emitTransition('tscDidStart');
+  }
+
+  tscDidEnd() {
+    if (this._pendingErrors.length) {
+      this.buildDeferred.reject(new Error(this._pendingErrors.join('\n')));
+    } else {
+      this.buildDeferred.resolve();
+    }
+
+    this._tscBuilding = false;
+    this._emitTransition('tscDidEnd');
+  }
+
+  didError(error) {
+    this._pendingErrors.push(error);
+    this._emitTransition('didError');
+  }
+
+  _emitTransition(event) {
+    debug(
+      `%s | broccoli: %s active nodes | tsc: %s (%s errors)`,
+      event,
+      this._buildingBroccoliNodes,
+      this._tscBuilding ? 'building' : 'idle',
+      this._pendingErrors.length
+    );
+  }
+};

--- a/lib/incremental-typescript-compiler/index.js
+++ b/lib/incremental-typescript-compiler/index.js
@@ -1,20 +1,17 @@
 'use strict';
 
-const tmpdir = require('./utilities/tmpdir');
-const mkdirp = require('mkdirp');
+const tmpdir = require('../utilities/tmpdir');
 const Funnel = require('broccoli-funnel');
 const MergeTrees = require('broccoli-merge-trees');
-const symlinkOrCopy = require('symlink-or-copy');
-const Plugin = require('broccoli-plugin');
-const RSVP = require('rsvp');
 const path = require('path');
-const fs = require('fs');
+const fs = require('fs-extra');
 const resolve = require('resolve');
-const compile = require('./utilities/compile');
+const compile = require('../utilities/compile');
 const ts = require('typescript');
+const TypescriptOutput = require('./typescript-output-plugin');
+const CompilerState = require('./compiler-state');
 
-const debugCompiler = require('debug')('ember-cli-typescript:compiler');
-const debugAutoresolve = require('debug')('ember-cli-typescript:autoresolve');
+const debugTsc = require('debug')('ember-cli-typescript:tsc');
 
 module.exports = class IncrementalTypescriptCompiler {
   constructor(app, project) {
@@ -29,21 +26,12 @@ module.exports = class IncrementalTypescriptCompiler {
     this.app = app;
     this.project = project;
     this.addons = this._discoverAddons(project, []);
-    this.maxBuildCount = 1;
-    this.autoresolveThreshold = 250;
+    this.state = new CompilerState();
 
-    this._buildDeferred = RSVP.defer();
-    this._isSynced = false;
-    this._pendingErrors = [];
-    this._triggerDir = `${this.outDir()}/.rebuild`;
-    this._pendingAutoresolve = null;
-    this._didAutoresolve = false;
     this._watchProgram = null;
   }
 
   treeForHost() {
-    let triggerTree = new Funnel(this._triggerDir, { destDir: 'app' });
-
     let appTree = new TypescriptOutput(this, {
       [`${this._relativeAppRoot()}/app`]: 'app',
     });
@@ -53,7 +41,7 @@ module.exports = class IncrementalTypescriptCompiler {
       [mirage]: 'app/mirage',
     });
 
-    let tree = new MergeTrees([triggerTree, mirageTree, appTree].filter(Boolean), { overwrite: true });
+    let tree = new MergeTrees([mirageTree, appTree].filter(Boolean), { overwrite: true });
     return new Funnel(tree, { srcDir: 'app' });
   }
 
@@ -85,14 +73,14 @@ module.exports = class IncrementalTypescriptCompiler {
   }
 
   buildPromise() {
-    return this._buildDeferred.promise;
+    return this.state.buildDeferred.promise;
   }
 
   outDir() {
     if (!this._outDir) {
       let outDir = path.join(tmpdir(), `e-c-ts-${process.pid}`);
       this._outDir = outDir;
-      mkdirp.sync(outDir);
+      fs.mkdirsSync(outDir);
     }
 
     return this._outDir;
@@ -104,47 +92,26 @@ module.exports = class IncrementalTypescriptCompiler {
       return;
     }
 
-    mkdirp.sync(this._triggerDir);
-    this._touchRebuildTrigger();
-
     let project = this.project;
     let outDir = this.outDir();
 
     this._watchProgram = compile(project, { outDir, watch: true }, {
+      watchedFileChanged: () => this.state.tscDidStart(),
+
       reportWatchStatus: (diagnostic) => {
         let text = diagnostic.messageText;
-
-        if (text.indexOf('Starting incremental compilation') !== -1) {
-          debugCompiler('tsc detected a file change');
-          this.willRebuild();
-          clearTimeout(this._pendingAutoresolve);
-        }
+        debugTsc(text);
 
         if (text.indexOf('Compilation complete') !== -1) {
-          debugCompiler('rebuild completed');
-
-          this.didSync();
-
-          if (this._didAutoresolve) {
-            this._touchRebuildTrigger();
-            this.maxBuildCount++;
-          }
-
-          clearTimeout(this._pendingAutoresolve);
-          this._didAutoresolve = false;
+          this.state.tscDidEnd();
         }
       },
 
       reportDiagnostic: (diagnostic) => {
         if (diagnostic.category !== 2) {
-          let message = ts.formatDiagnostic(diagnostic, {
-            getCanonicalFileName: path => path,
-            getCurrentDirectory: ts.sys.getCurrentDirectory,
-            getNewLine: () => ts.sys.newLine,
-          });
-
+          let message = this._formatDiagnosticMessage(diagnostic);
           if (this._shouldFailOnTypeError()) {
-            this.didError(message);
+            this.state.didError(message);
           } else {
             this.project.ui.write(message);
           }
@@ -153,40 +120,16 @@ module.exports = class IncrementalTypescriptCompiler {
     });
   }
 
-  willRebuild() {
-    if (this._isSynced) {
-      this._isSynced = false;
-      this._buildDeferred = RSVP.defer();
-
-      // Schedule a timer to automatically resolve if tsc doesn't pick up any file changes in a
-      // short period. This may happen if a non-TS file changed, or if the tsc watcher is
-      // drastically behind watchman. If the latter happens, we'll explicitly touch a file in the
-      // broccoli output in order to ensure the changes are picked up.
-      this._pendingAutoresolve = setTimeout(() => {
-        debugAutoresolve('no tsc rebuild; autoresolving...');
-
-        this.didSync();
-        this._didAutoresolve = true;
-      }, this.autoresolveThreshold);
-    }
-  }
-
-  didError(message) {
-    this._pendingErrors.push(message);
-  }
-
-  didSync() {
-    this._isSynced = true;
-    if (this._pendingErrors.length) {
-      this._buildDeferred.reject(new Error(this._pendingErrors.join('\n')));
-      this._pendingErrors = [];
-    } else {
-      this._buildDeferred.resolve();
-    }
-  }
-
   getProgram() {
     return this._watchProgram.getProgram();
+  }
+
+  _formatDiagnosticMessage(diagnostic) {
+    return ts.formatDiagnostic(diagnostic, {
+      getCanonicalFileName: path => path,
+      getCurrentDirectory: ts.sys.getCurrentDirectory,
+      getNewLine: () => ts.sys.newLine,
+    });
   }
 
   _shouldFailOnTypeError() {
@@ -217,11 +160,6 @@ module.exports = class IncrementalTypescriptCompiler {
         return source;
       }
     }
-  }
-
-  _touchRebuildTrigger() {
-    debugAutoresolve('touching rebuild trigger.');
-    fs.writeFileSync(`${this._triggerDir}/tsc-delayed-rebuild`, '', 'utf-8');
   }
 
   _discoverAddons(node, addons) {
@@ -261,43 +199,3 @@ module.exports = class IncrementalTypescriptCompiler {
   }
 };
 
-class TypescriptOutput extends Plugin {
-  constructor(compiler, paths) {
-    super([]);
-    this.compiler = compiler;
-    this.paths = paths;
-    this.buildCount = 0;
-  }
-
-  build() {
-    this.buildCount++;
-
-    // We use this to keep track of the build state between the various
-    // Broccoli trees and tsc; when either tsc or broccoli notices a file
-    // change, we immediately invalidate the previous build output.
-    if (this.buildCount > this.compiler.maxBuildCount) {
-      debugCompiler('broccoli detected a file change');
-      this.compiler.maxBuildCount = this.buildCount;
-      this.compiler.willRebuild();
-    }
-
-    debugCompiler('waiting for tsc output', this.paths);
-    return this.compiler.buildPromise().then(() => {
-      debugCompiler('tsc build complete', this.paths);
-      for (let relativeSrc of Object.keys(this.paths)) {
-        let src = `${this.compiler.outDir()}/${relativeSrc}`;
-        let dest = `${this.outputPath}/${this.paths[relativeSrc]}`;
-        if (fs.existsSync(src)) {
-          let dir = path.dirname(dest);
-          if (dir !== '.') {
-            mkdirp.sync(dir);
-          }
-
-          symlinkOrCopy.sync(src, dest);
-        } else {
-          mkdirp.sync(dest);
-        }
-      }
-    });
-  }
-}

--- a/lib/incremental-typescript-compiler/typescript-output-plugin.js
+++ b/lib/incremental-typescript-compiler/typescript-output-plugin.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const Plugin = require('broccoli-plugin');
+const fs = require('fs-extra');
+const path = require('path');
+const symlinkOrCopy = require('symlink-or-copy');
+
+/*
+ * We don't insert the output of the TypeScript compiler directly into
+ * the broccoli pipeline, as that would cause double rebuilds (once for
+ * the change to the original .ts file, then another for the change to
+ * the resulting .js file). Instead, we use this Broccoli plugin to
+ * essentially provide a lightweight 'view' into the compiler output,
+ * blocking the rebuild triggered by the original .ts file until the
+ * corresponding .js file is ready.
+ */
+module.exports = class TypescriptOutput extends Plugin {
+  constructor(compiler, paths) {
+    super([]);
+    this.compiler = compiler;
+    this.paths = paths;
+  }
+
+  build() {
+    this.compiler.state.broccoliDidStart();
+
+    return this.compiler
+      .buildPromise()
+      .then(() => {
+        for (let relativeSrc of Object.keys(this.paths)) {
+          let src = `${this.compiler.outDir()}/${relativeSrc}`;
+          let dest = `${this.outputPath}/${this.paths[relativeSrc]}`;
+          if (fs.existsSync(src)) {
+            let dir = path.dirname(dest);
+            if (dir !== '.') {
+              fs.mkdirsSync(dir);
+            }
+
+            symlinkOrCopy.sync(src, dest);
+          } else {
+            fs.mkdirsSync(dest);
+          }
+        }
+      })
+      .finally(() => this.compiler.state.broccoliDidEnd());
+  }
+};

--- a/lib/utilities/compile.js
+++ b/lib/utilities/compile.js
@@ -1,14 +1,15 @@
 /* eslint-env node */
 'use strict';
 
-const mkdirp = require('mkdirp');
 const ts = require('typescript');
 const chokidar = require('chokidar');
 const fs = require('fs-extra');
+const path = require('path');
+const debugWatcher = require('debug')('ember-cli-typescript:watcher');
 
 module.exports = function compile(project, tsOptions, callbacks) {
   // Ensure the output directory is created even if no files are generated
-  mkdirp.sync(tsOptions.outDir);
+  fs.mkdirsSync(tsOptions.outDir);
 
   let fullOptions = Object.assign({
     rootDir: project.root,
@@ -21,7 +22,7 @@ module.exports = function compile(project, tsOptions, callbacks) {
   let host = ts.createWatchCompilerHost(
     configPath,
     fullOptions,
-    buildWatchHooks(ts.sys),
+    buildWatchHooks(ts.sys, callbacks),
     createProgram,
     diagnosticCallback(callbacks.reportDiagnostic),
     diagnosticCallback(callbacks.reportWatchStatus)
@@ -41,11 +42,21 @@ function diagnosticCallback(callback) {
   }
 }
 
-function buildWatchHooks(sys) {
+function buildWatchHooks(sys, callbacks) {
   let watchedFiles = new Map();
+  let fileChanged = (type, path) => {
+    debugWatcher('file changed (%s) %s', type, path);
+    if (callbacks.watchedFileChanged) {
+      callbacks.watchedFileChanged();
+    }
+  };
 
   return Object.assign({}, sys, {
-    watchFile(file, callback) {
+    watchFile(_file, callback) {
+      // tsc is inconsistent about whether it provides relative or absolute paths
+      let file = path.resolve(_file);
+
+      debugWatcher('watchFile %s', file);
       watchedFiles.set(file, callback);
 
       return {
@@ -63,10 +74,14 @@ function buildWatchHooks(sys) {
 
       watcher.on('all', (type, path) => {
         path = path.replace(/\\/g, '/'); // Normalize Windows
-        if (type === 'add') {
+        if (type === 'add' && path.endsWith('.ts')) {
+          fileChanged(type, path);
           callback(path);
         } else if (watchedFiles.has(path)) {
+          fileChanged(type, path);
           watchedFiles.get(path)(path, type === 'change' ? 1 : 2);
+        } else {
+          debugWatcher('unknown file event %s %s', type, path);
         }
       });
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "exists-sync": "^0.0.4",
     "fs-extra": "^5.0.0",
     "inflection": "^1.12.0",
-    "mkdirp": "^0.5.1",
     "resolve": "^1.5.0",
     "rimraf": "^2.6.2",
     "rsvp": "^4.8.1",


### PR DESCRIPTION
This factors out the juggling we've been doing between Broccoli and `tsc` into a dedicated class, eliminating some crufty code and (I believe) fixing #191. I've also built in some additional logging, which in combination with the cleaner separation of code should hopefully make debugging simpler, should other issues turn up in the future.