### PR TITLE
Fix Windows path issue

### DIFF
--- a/lib/utilities/compile.js
+++ b/lib/utilities/compile.js
@@ -73,7 +73,6 @@ function buildWatchHooks(sys, callbacks) {
       let watcher = chokidar.watch(dir, { ignored, ignoreInitial: true });
 
       watcher.on('all', (type, path) => {
-        path = path.replace(/\\/g, '/'); // Normalize Windows
         if (type === 'add' && path.endsWith('.ts')) {
           fileChanged(type, path);
           callback(path);


### PR DESCRIPTION
The fix turned out to be as simple as removing the offending line.

For posterity: originally, that line was added because the keys of `watchedFiles` all had forward slashes. That is no longer the case.