### PR TITLE
Simplify watcher

### DIFF
--- a/lib/utilities/compile.js
+++ b/lib/utilities/compile.js
@@ -1,11 +1,9 @@
 /* eslint-env node */
 'use strict';
 
-const ts = require('typescript');
 const chokidar = require('chokidar');
 const fs = require('fs-extra');
-const path = require('path');
-const debugWatcher = require('debug')('ember-cli-typescript:watcher');
+const debug = require('debug')('ember-cli-typescript:tsc:trace');
 
 module.exports = function compile(project, tsOptions, callbacks) {
   // Ensure the output directory is created even if no files are generated
@@ -14,9 +12,12 @@ module.exports = function compile(project, tsOptions, callbacks) {
   let fullOptions = Object.assign({
     rootDir: project.root,
     allowJs: false,
-    noEmit: false
+    noEmit: false,
+    diagnostics: debug.enabled,
+    extendedDiagnostics: debug.enabled
   }, tsOptions);
 
+  let ts = project.require('typescript');
   let configPath = ts.findConfigFile('./', ts.sys.fileExists, 'tsconfig.json');
   let createProgram = ts.createEmitAndSemanticDiagnosticsBuilderProgram;
   let host = ts.createWatchCompilerHost(
@@ -27,6 +28,10 @@ module.exports = function compile(project, tsOptions, callbacks) {
     diagnosticCallback(callbacks.reportDiagnostic),
     diagnosticCallback(callbacks.reportWatchStatus)
   );
+
+  if (debug.enabled) {
+    host.trace = str => debug(str.trim());
+  }
 
   return ts.createWatchProgram(host);
 };
@@ -43,29 +48,8 @@ function diagnosticCallback(callback) {
 }
 
 function buildWatchHooks(sys, callbacks) {
-  let watchedFiles = new Map();
-  let fileChanged = (type, path) => {
-    debugWatcher('file changed (%s) %s', type, path);
-    if (callbacks.watchedFileChanged) {
-      callbacks.watchedFileChanged();
-    }
-  };
-
   return Object.assign({}, sys, {
-    watchFile(_file, callback) {
-      // tsc is inconsistent about whether it provides relative or absolute paths
-      let file = path.resolve(_file);
-
-      debugWatcher('watchFile %s', file);
-      watchedFiles.set(file, callback);
-
-      return {
-        close() {
-          watchedFiles.delete(file);
-        }
-      };
-    },
-
+    watchFile: null,
     watchDirectory(dir, callback) {
       if (!fs.existsSync(dir)) return;
 
@@ -73,14 +57,10 @@ function buildWatchHooks(sys, callbacks) {
       let watcher = chokidar.watch(dir, { ignored, ignoreInitial: true });
 
       watcher.on('all', (type, path) => {
-        if (type === 'add' && path.endsWith('.ts')) {
-          fileChanged(type, path);
-          callback(path);
-        } else if (watchedFiles.has(path)) {
-          fileChanged(type, path);
-          watchedFiles.get(path)(path, type === 'change' ? 1 : 2);
-        } else {
-          debugWatcher('unknown file event %s %s', type, path);
+        callback(path);
+
+        if (path.endsWith('.ts') && callbacks.watchedFileChanged) {
+          callbacks.watchedFileChanged();
         }
       });
 


### PR DESCRIPTION
I worked some over the weekend on an implementation of #192, and in the process put the new watcher implementation through its paces. I found a couple scenarios (e.g. deleting a whole tree of directories) where the compiler would wind up hanging on to an orphaned reference to a file that no longer existed, and after comparing diagnostic output between our watcher and one of the default implementations, realized that their directory watcher was much more active than ours.

It seems with our chokidar setup we can forgo `watchFile` completely and just trigger the `watchDirectory` callback whenever a file within that directory changes. This eliminated all of the weird behavior I'd been seeing, and it got tsc's diagnostic output when using our watcher inline with what you'd see from the default one.