### PR TITLE
Lock @types/node to prevent conflicts

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "devDependencies": {
     "@types/ember": "2.8.13",
     "@types/ember-qunit": "^3.0.1",
-    "@types/node": "*",
+    "@types/node": "^9.6.5",
     "@types/qunit": "^2.0.31",
     "broccoli-asset-rev": "^2.6.0",
     "ember-cli": "~2.18.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -56,9 +56,9 @@
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/@types/jquery/-/jquery-3.3.1.tgz#55758d44d422756d6329cbf54e6d41931d7ba28f"
 
-"@types/node@*":
-  version "9.6.5"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.5.tgz#ee700810fdf49ac1c399fc5980b7559b3e5a381d"
+"@types/node@^9.6.5":
+  version "9.6.7"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.7.tgz#5f3816d1db2155edcde1b2e3aa5d0e5c520cb564"
 
 "@types/qunit@^2.0.31":
   version "2.5.0"


### PR DESCRIPTION
This fixes the test failures for me locally that we're seeing on master and in #199. Let's see if Travis and Appveyor agree!