### PR TITLE
Don't require TypeScript before we've installed it

### DIFF
--- a/lib/incremental-typescript-compiler/index.js
+++ b/lib/incremental-typescript-compiler/index.js
@@ -7,7 +7,6 @@ const path = require('path');
 const fs = require('fs-extra');
 const resolve = require('resolve');
 const compile = require('../utilities/compile');
-const ts = require('typescript');
 const TypescriptOutput = require('./typescript-output-plugin');
 const CompilerState = require('./compiler-state');
 
@@ -28,6 +27,7 @@ module.exports = class IncrementalTypescriptCompiler {
     this.addons = this._discoverAddons(project, []);
     this.state = new CompilerState();
 
+    this._ts = project.require('typescript');
     this._watchProgram = null;
   }
 
@@ -125,10 +125,10 @@ module.exports = class IncrementalTypescriptCompiler {
   }
 
   _formatDiagnosticMessage(diagnostic) {
-    return ts.formatDiagnostic(diagnostic, {
+    return this._ts.formatDiagnostic(diagnostic, {
       getCanonicalFileName: path => path,
-      getCurrentDirectory: ts.sys.getCurrentDirectory,
-      getNewLine: () => ts.sys.newLine,
+      getCurrentDirectory: this._ts.sys.getCurrentDirectory,
+      getNewLine: () => this._ts.sys.newLine,
     });
   }
 

--- a/package.json
+++ b/package.json
@@ -96,9 +96,6 @@
   "resolutions": {
     "@types/ember": "2.8.13"
   },
-  "peerDependencies": {
-    "typescript": "^2.4.2"
-  },
   "engines": {
     "node": "^4.5 || 6.* || >= 7.*"
   },


### PR DESCRIPTION
This fixes #205 and removes `typescript` from our peerDependencies so that ESLint will yell at us if we do this again.