### PR TITLE
Anchor watcher ignore patterns at the project root

### DIFF
--- a/lib/utilities/compile.js
+++ b/lib/utilities/compile.js
@@ -3,6 +3,7 @@
 
 const chokidar = require('chokidar');
 const fs = require('fs-extra');
+const escapeRegex = require('escape-string-regexp');
 const debug = require('debug')('ember-cli-typescript:tsc:trace');
 
 module.exports = function compile(project, tsOptions, callbacks) {
@@ -23,7 +24,7 @@ module.exports = function compile(project, tsOptions, callbacks) {
   let host = ts.createWatchCompilerHost(
     configPath,
     fullOptions,
-    buildWatchHooks(ts.sys, callbacks),
+    buildWatchHooks(project, ts.sys, callbacks),
     createProgram,
     diagnosticCallback(callbacks.reportDiagnostic),
     diagnosticCallback(callbacks.reportWatchStatus)
@@ -47,13 +48,17 @@ function diagnosticCallback(callback) {
   }
 }
 
-function buildWatchHooks(sys, callbacks) {
+function buildWatchHooks(project, sys, callbacks) {
+  let root = escapeRegex(project.root);
+  let sep = `[/\\\\]`;
+  let patterns = ['\\..*?', 'dist', 'node_modules', 'tmp'];
+  let ignored = new RegExp(`^${root}${sep}(${patterns.join('|')})${sep}`);
+
   return Object.assign({}, sys, {
     watchFile: null,
     watchDirectory(dir, callback) {
       if (!fs.existsSync(dir)) return;
 
-      let ignored = /\/(\..*?|dist|node_modules|tmp)\//;
       let watcher = chokidar.watch(dir, { ignored, ignoreInitial: true });
 
       watcher.on('all', (type, path) => {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "ember-cli-valid-component-name": "^1.0.0",
     "ember-cli-version-checker": "^2.1.0",
     "ember-router-generator": "^1.2.3",
+    "escape-string-regexp": "^1.0.5",
     "execa": "^0.9.0",
     "exists-sync": "^0.0.4",
     "fs-extra": "^5.0.0",


### PR DESCRIPTION
This fixes #206. I don't think there's a super cheap way to add meaningful test coverage for the specific case that was hit there, though #202 would give us a slightly heavier option if we wanted to take it.