### PR TITLE
Stop inspecting output strings to determine when builds complete

### DIFF
--- a/lib/incremental-typescript-compiler/index.js
+++ b/lib/incremental-typescript-compiler/index.js
@@ -97,14 +97,11 @@ module.exports = class IncrementalTypescriptCompiler {
 
     this._watchProgram = compile(project, { outDir, watch: true }, {
       watchedFileChanged: () => this.state.tscDidStart(),
+      buildComplete: () => this.state.tscDidEnd(),
 
       reportWatchStatus: (diagnostic) => {
         let text = diagnostic.messageText;
         debugTsc(text);
-
-        if (text.indexOf('Compilation complete') !== -1) {
-          this.state.tscDidEnd();
-        }
       },
 
       reportDiagnostic: (diagnostic) => {

--- a/lib/utilities/compile.js
+++ b/lib/utilities/compile.js
@@ -19,23 +19,37 @@ module.exports = function compile(project, tsOptions, callbacks) {
   }, tsOptions);
 
   let ts = project.require('typescript');
+  let host = createWatchCompilerHost(ts, fullOptions, project, callbacks);
+
+  return ts.createWatchProgram(host);
+};
+
+function createWatchCompilerHost(ts, options, project, callbacks) {
   let configPath = ts.findConfigFile('./', ts.sys.fileExists, 'tsconfig.json');
   let createProgram = ts.createEmitAndSemanticDiagnosticsBuilderProgram;
   let host = ts.createWatchCompilerHost(
     configPath,
-    fullOptions,
+    options,
     buildWatchHooks(project, ts.sys, callbacks),
     createProgram,
     diagnosticCallback(callbacks.reportDiagnostic),
     diagnosticCallback(callbacks.reportWatchStatus)
   );
 
+  let afterCreate = host.afterProgramCreate;
+  host.afterProgramCreate = function() {
+    afterCreate.apply(this, arguments);
+    if (callbacks.buildComplete) {
+      callbacks.buildComplete();
+    }
+  };
+
   if (debug.enabled) {
     host.trace = str => debug(str.trim());
   }
 
-  return ts.createWatchProgram(host);
-};
+  return host;
+}
 
 function diagnosticCallback(callback) {
   if (callback) {


### PR DESCRIPTION
TypeScript 2.9 tweaked their diagnostic message when a build completes, which prompted me to finally go find a hook for reporting rebuilds that doesn't involve string sniffing. I tested this against 2.7, 2.8, and `next` and everything looked good across those three.

I'm also going to look at including different `typescript` versions in our build matrix, but figured I'd do that in a separate PR.