### PR TITLE
Update build matrix to cover TS + Ember CLI versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,27 +16,20 @@ env:
     # See https://git.io/vdao3 for details.
     - JOBS=1
   matrix:
-    # we recommend new addons test the current and previous LTS
-    # as well as latest stable release (bonus points to beta/canary)
-    - EMBER_TRY_SCENARIO=ember-lts-2.12
-    - EMBER_TRY_SCENARIO=ember-lts-2.16
-    - EMBER_TRY_SCENARIO=ember-lts-2.18
-    - EMBER_TRY_SCENARIO=ember-release
-    - EMBER_TRY_SCENARIO=ember-beta
-    - EMBER_TRY_SCENARIO=ember-canary
-    - EMBER_TRY_SCENARIO=ember-default
-    - EMBER_TRY_SCENARIO=integrated-node-tests
+    - EMBER_TRY_SCENARIO=defaults
+    - EMBER_TRY_SCENARIO=typescript-release
+    - EMBER_TRY_SCENARIO=typescript-beta
+    - EMBER_TRY_SCENARIO=ember-cli-release
+    - EMBER_TRY_SCENARIO=ember-cli-beta
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:
   - bash ./is_md_only.sh && MD_ONLY=true && echo "Only .md files have changed!" || test true
 
 install:
-  - test $MD_ONLY && echo "Skipped!" || yarn install --no-lockfile
+  - test $MD_ONLY && echo "Skipped!" || yarn install
 
 script:
   - test $MD_ONLY && echo "Skipped!" || yarn lint:js

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,8 +27,7 @@ cache:
 test_script:
   # Output useful info for debugging.
   - yarn versions
-  - cmd: yarn ember try:one ember-release
-  - cmd: yarn ember try:one integrated-node-tests
+  - cmd: yarn ember try:one defaults
 
 # Don't actually build.
 build: off

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,80 +1,44 @@
-'use strict';
-
-const getChannelURL = require('ember-source-channel-url');
-
-module.exports = function() {
-  return Promise.all([
-    getChannelURL('release'),
-    getChannelURL('beta'),
-    getChannelURL('canary'),
-  ]).then(urls => {
-    return {
-      useYarn: true,
-      scenarios: [
-        {
-          name: 'integrated-node-tests',
-          command: 'yarn nodetest',
-          npm: {
-            devDependencies: {
-              'ember-cli-qunit': null,
-            },
-          },
+module.exports = {
+  useYarn: true,
+  command: 'ember test && yarn nodetest',
+  scenarios: [
+    {
+      name: 'defaults',
+      npm: {
+        devDependencies: {},
+      },
+    },
+    {
+      name: 'typescript-release',
+      npm: {
+        devDependencies: {
+          typescript: 'latest',
         },
-        {
-          name: 'ember-lts-2.12',
-          npm: {
-            devDependencies: {
-              'ember-source': '~2.12.0',
-            },
-          },
+      },
+    },
+    {
+      name: 'typescript-beta',
+      npm: {
+        devDependencies: {
+          typescript: 'next',
         },
-        {
-          name: 'ember-lts-2.16',
-          npm: {
-            devDependencies: {
-              'ember-source': '~2.16.0',
-            },
-          },
+      },
+    },
+    {
+      name: 'ember-cli-release',
+      npm: {
+        devDependencies: {
+          'ember-cli': 'latest',
         },
-        {
-          name: 'ember-lts-2.18',
-          npm: {
-            devDependencies: {
-              'ember-source': '~2.18.0',
-            },
-          },
+      },
+    },
+    {
+      name: 'ember-cli-beta',
+      npm: {
+        devDependencies: {
+          'ember-cli': 'beta',
         },
-        {
-          name: 'ember-release',
-          npm: {
-            devDependencies: {
-              'ember-source': urls[0],
-            },
-          },
-        },
-        {
-          name: 'ember-beta',
-          npm: {
-            devDependencies: {
-              'ember-source': urls[1],
-            },
-          },
-        },
-        {
-          name: 'ember-canary',
-          npm: {
-            devDependencies: {
-              'ember-source': urls[2],
-            },
-          },
-        },
-        {
-          name: 'ember-default',
-          npm: {
-            devDependencies: {},
-          },
-        },
-      ],
-    };
-  });
+      },
+    },
+  ],
 };


### PR DESCRIPTION
Ok, #210 is merged and the build is green, so it's probably time for me to write up a proper description here.

This updates our testing approach so that rather than hitting a bunch of different versions of Ember, we run both the browser and the node tests against:
 - the current dependencies in our lockfile
 - the current `ember-cli` release
 - the current `ember-cli` beta
 - the current `typescript` release
 - the current `typescript` beta

Appveyor continues to only run against our default dependencies as before.

A few things we could opt to do down the line:
 - expand our coverage to include older versions of `ember-cli` and/or `typescript`, once we firm up our official support policy
 - adopt [Travis stages](https://docs.travis-ci.com/user/build-stages/) to e.g. gate the versioned jobs on the `defaults` one so that we don't waste cycles on runs that will definitely fail