### PR TITLE
Fix handling for `noEmitOnError: true`

### DIFF
--- a/lib/utilities/compile.js
+++ b/lib/utilities/compile.js
@@ -40,7 +40,9 @@ function createWatchCompilerHost(ts, options, project, callbacks) {
   host.afterProgramCreate = function() {
     afterCreate.apply(this, arguments);
     if (callbacks.buildComplete) {
-      callbacks.buildComplete();
+      // Use nextTick to preserve ordering between the `buildComplete` callback
+      // and the diagnostic hooks below
+      process.nextTick(() => callbacks.buildComplete());
     }
   };
 


### PR DESCRIPTION
This broke in #209, and was caught by the tests in #202 when I merged master into that branch. In theory landing this should turn the build for that PR green (locally it does, at least).