### PR TITLE
Remove `node_modules` from chokidar's ignore regex

### DIFF
--- a/lib/utilities/compile.js
+++ b/lib/utilities/compile.js
@@ -67,7 +67,7 @@ function diagnosticCallback(callback) {
 function buildWatchHooks(project, sys, callbacks) {
   let root = escapeRegex(project.root);
   let sep = `[/\\\\]`;
-  let patterns = ['\\..*?', 'dist', 'node_modules', 'tmp'];
+  let patterns = ['\\..*?', 'dist', 'tmp'];
   let ignored = new RegExp(`^${root}${sep}(${patterns.join('|')})${sep}`);
 
   return Object.assign({}, sys, {

--- a/lib/utilities/compile.js
+++ b/lib/utilities/compile.js
@@ -65,17 +65,17 @@ function diagnosticCallback(callback) {
 }
 
 function buildWatchHooks(project, sys, callbacks) {
-  let root = escapeRegex(project.root);
-  let sep = `[/\\\\]`;
-  let patterns = ['\\..*?', 'dist', 'tmp'];
-  let ignored = new RegExp(`^${root}${sep}(${patterns.join('|')})${sep}`);
+  let ignorePatterns = ['\\..*?', 'dist', 'tmp', 'node_modules'];
 
   return Object.assign({}, sys, {
     watchFile: null,
     watchDirectory(dir, callback) {
       if (!fs.existsSync(dir)) return;
 
-      let watcher = chokidar.watch(dir, { ignored, ignoreInitial: true });
+      let watcher = chokidar.watch(dir, {
+        ignored: buildIgnoreRegex(dir, ignorePatterns),
+        ignoreInitial: true
+      });
 
       watcher.on('all', (type, path) => {
         callback(path);
@@ -88,4 +88,10 @@ function buildWatchHooks(project, sys, callbacks) {
       return watcher;
     }
   });
+}
+
+function buildIgnoreRegex(rootDir, patterns) {
+  let base = escapeRegex(rootDir);
+  let sep = `[/\\\\]`;
+  return new RegExp(`^${base}${sep}(${patterns.join('|')})${sep}`);
 }


### PR DESCRIPTION
Excluding `node_modules` from watching was causing changes in linked addons not to be picked up. Removing that element from the exclude patterns fixes the problem, but I'm not positive why it was in there in the first place.

@tansongyang do you remember the context there? Were there Windows-related issues with allowing the watcher to include `node_modules`?