### PR TITLE
Avoid an infinite loop when requesting compiler options

### DIFF
--- a/lib/incremental-typescript-compiler/index.js
+++ b/lib/incremental-typescript-compiler/index.js
@@ -29,6 +29,7 @@ module.exports = class IncrementalTypescriptCompiler {
 
     this._ts = project.require('typescript');
     this._watchProgram = null;
+    this._compilerOptions = null;
   }
 
   treeForHost() {
@@ -115,6 +116,10 @@ module.exports = class IncrementalTypescriptCompiler {
         }
       }
     });
+
+    // Prefetch the compiler options, because fetching them while reporting a diagnostic
+    // can result in a diagnostic-reporting loop in certain states
+    this._compilerOptions = this.getProgram().getCompilerOptions();
   }
 
   getProgram() {
@@ -130,8 +135,7 @@ module.exports = class IncrementalTypescriptCompiler {
   }
 
   _shouldFailOnTypeError() {
-    let options = this.getProgram().getCompilerOptions();
-    return !!options.noEmitOnError;
+    return !!this._compilerOptions.noEmitOnError;
   }
 
   _mirageDirectory() {


### PR DESCRIPTION
I've made this fix on various different half-baked branches (I believe the type generation one currently has it), but we should get it on master before cutting 1.3.2 to hopefully cut out any lingering infinite-loop scenarios.

@jamescdavis if you have a minute, could you give this a look this afternoon?