### PR TITLE
[docs] Readme: "Getting Help" w/ Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATES/BUILD_BUG.md
+++ b/.github/ISSUE_TEMPLATES/BUILD_BUG.md
@@ -17,7 +17,7 @@
 
 -->
 
-### Please paste your `tconfig.json` and `tslint.json` (if applicable) below
+### Please paste your `tconfig.json` and `tslint.json` or `eslint.json` (if applicable) below
 
 
 <details><summary><b>My tsconfig.json</b></summary><pre>
@@ -26,7 +26,7 @@
   
 </pre></details>
 
-<details><summary><b>My tslint.json</b></summary><pre>
+<details><summary><b>My tslint.json or eslint.json</b></summary><pre>
 
   <!-- Paste your tslint.json here -->
 

--- a/.github/ISSUE_TEMPLATES/BUILD_BUG.md
+++ b/.github/ISSUE_TEMPLATES/BUILD_BUG.md
@@ -1,0 +1,50 @@
+<!-- This template is for bugs relating to Ember.js typescript support & infrastructure.
+     Please fill out all of the required information below -->
+
+### Please paste the output of `ember -v` here
+<!-- example
+
+  ember-cli: 3.1.4
+  node: 10.5.0
+  os: darwin x64
+
+-->
+
+### Please paste the output of `tsc -v` here
+<!-- example
+
+  Version 2.9.2
+
+-->
+
+### Please paste your `tconfig.json` and `tslint.json` (if applicable) below
+
+
+<details><summary><b>My tsconfig.json</b></summary><pre>
+
+  <!-- Paste your tsconfig.json here -->
+  
+</pre></details>
+
+<details><summary><b>My tslint.json</b></summary><pre>
+
+  <!-- Paste your tslint.json here -->
+
+</pre></details>
+
+### What are instructions we can follow to reproduce the issue?
+```sh
+ember new sample; cd ./sample # Create a new ember app
+ember install ember-cli-typescript # Set up typescript support
+
+>> Your Instructions Go Here <<
+
+```
+<!-- example: "Create a new route, add an action to it as shown in the following code sample" -->
+
+
+### Now about that bug. What did you expect to see?
+<!-- example: "I expected to be able to invoke my function foo() -->
+
+### What happened instead?
+<!-- example: "TypeScript seems to think that there is no function foo()" -->

--- a/.github/ISSUE_TEMPLATES/BUILD_ENHANCEMENT.md
+++ b/.github/ISSUE_TEMPLATES/BUILD_ENHANCEMENT.md
@@ -1,0 +1,12 @@
+<!-- This template is for enhancements relating to Ember.js typescript support & infrastructure.
+     Please fill out all of the required information below -->
+
+### Please write a user story for this feature
+
+Follow the form
+
+> *As a **role**, I want **feature** so that **reason**.* 
+
+> Example: 
+>
+> As an **addon publisher**, I want tobe able to **precompile my addon's typescript into js**, so that **my consumers can use my code, regardless of whether their app is written in typescript**

--- a/.github/ISSUE_TEMPLATES/CONFIG_ISSUE.md
+++ b/.github/ISSUE_TEMPLATES/CONFIG_ISSUE.md
@@ -17,7 +17,7 @@
 
 -->
 
-### Please paste your `tconfig.json` and `tslint.json` (if applicable) below
+### Please paste your `tconfig.json` and `tslint.json` or `eslint.json` (if applicable) below
 
 
 <details><summary><b>My tsconfig.json</b></summary><pre>
@@ -26,7 +26,7 @@
   
 </pre></details>
 
-<details><summary><b>My tslint.json</b></summary><pre>
+<details><summary><b>My tslint.json or eslint.json</b></summary><pre>
 
   <!-- Paste your tslint.json here -->
 

--- a/.github/ISSUE_TEMPLATES/CONFIG_ISSUE.md
+++ b/.github/ISSUE_TEMPLATES/CONFIG_ISSUE.md
@@ -1,0 +1,51 @@
+<!-- This template is for configuration issues relating to Ember.js typescript support & infrastructure.
+     Please fill out all of the required information below -->
+
+### Please paste the output of `ember -v` here
+<!-- example
+
+  ember-cli: 3.1.4
+  node: 10.5.0
+  os: darwin x64
+
+-->
+
+### Please paste the output of `tsc -v` here
+<!-- example
+
+  Version 2.9.2
+
+-->
+
+### Please paste your `tconfig.json` and `tslint.json` (if applicable) below
+
+
+<details><summary><b>My tsconfig.json</b></summary><pre>
+
+  <!-- Paste your tsconfig.json here -->
+  
+</pre></details>
+
+<details><summary><b>My tslint.json</b></summary><pre>
+
+  <!-- Paste your tslint.json here -->
+
+</pre></details>
+
+
+### What are instructions we can follow to reproduce the issue?
+```sh
+ember new sample; cd ./sample # Create a new ember app
+ember install ember-cli-typescript # Set up typescript support
+
+>> Your Instructions Go Here <<
+
+```
+<!-- example: "Create a new route, add an action to it as shown in the following code sample" -->
+
+
+### Now about that bug. What did you expect to see?
+<!-- example: "I expected to be able to invoke my function foo() -->
+
+### What happened instead?
+<!-- example: "TypeScript seems to think that there is no function foo()" -->

--- a/.github/ISSUE_TEMPLATES/TYPES_BUG.md
+++ b/.github/ISSUE_TEMPLATES/TYPES_BUG.md
@@ -1,0 +1,28 @@
+<!-- This template is for bugs relating to Ember.js type information.
+     Please fill out all of the required information below -->
+
+### Which package(s) does this problem pertain to?
+  - [ ] @types/ember
+  - [ ] @types/ember-data
+  - [ ] @types/rsvp
+  - [ ] @types/ember-test-helpers
+  - [ ] @types/ember-testing-helpers
+  - [ ] Other
+  - [ ] I don't know
+
+### What are instructions we can follow to reproduce the issue?
+```sh
+ember new sample; cd ./sample # Create a new ember app
+ember install ember-cli-typescript # Set up typescript support
+
+>> Your Instructions Go Here <<
+
+```
+<!-- example: "Create a new route, add an action to it as shown in the following code sample" -->
+
+
+### Now about that bug. What did you expect to see?
+<!-- example: "I expected to be able to invoke my function foo() -->
+
+### What happened instead?
+<!-- example: "TypeScript seems to think that there is no function foo()" -->

--- a/.github/ISSUE_TEMPLATES/TYPES_ENHANCEMENT.md
+++ b/.github/ISSUE_TEMPLATES/TYPES_ENHANCEMENT.md
@@ -1,7 +1,7 @@
 <!-- This template is for enhancements relating to Ember.js type information.
      Please fill out all of the required information below -->
 
-### Which package(s) does this problem pertain to?
+### Which package(s) does this enhancement pertain to?
   - [ ] @types/ember
   - [ ] @types/ember-data
   - [ ] @types/rsvp

--- a/.github/ISSUE_TEMPLATES/TYPES_ENHANCEMENT.md
+++ b/.github/ISSUE_TEMPLATES/TYPES_ENHANCEMENT.md
@@ -1,0 +1,22 @@
+<!-- This template is for enhancements relating to Ember.js type information.
+     Please fill out all of the required information below -->
+
+### Which package(s) does this problem pertain to?
+  - [ ] @types/ember
+  - [ ] @types/ember-data
+  - [ ] @types/rsvp
+  - [ ] @types/ember-test-helpers
+  - [ ] @types/ember-testing-helpers
+  - [ ] Other
+  - [ ] I don't know
+
+
+### Please write a user story for this feature
+
+Follow the form
+
+> *As a **role**, I want **feature** so that **reason**.* 
+
+> Example: 
+>
+> As an **addon publisher**, I want tobe able to **precompile my addon's typescript into js**, so that **my consumers can use my code, regardless of whether their app is written in typescript**

--- a/.github/ISSUE_TEMPLATES/default.md
+++ b/.github/ISSUE_TEMPLATES/default.md
@@ -1,0 +1,38 @@
+<!-- 
+  == READ THIS FIRST ==
+
+  To ensure your issue is given the attention it deserves, we have several templates for specific purposes.
+  Please use the templates below if they apply (via the associated URLs), and post a generalized issue only as a last resort.
+
+  =============[ FOR BUGS ]=============
+    
+    - Relating to type information: 
+    
+      https://github.com/typed-ember/ember-cli-typescript/issues/new?template=TYPES_BUG.md&labels=%5Btypes%5D&title=%5B@types/ember%20bug%5D%20-%20%3CYOUR_DESCRIPTION_HERE%3E
+    
+    - Relating to build infrastructure: 
+      
+      https://github.com/typed-ember/ember-cli-typescript/issues/new?template=BUILD_BUG.md&labels=%5Bbuild%5D&title=%5Bbug%5D%20-%20%3CYOUR_DESCRIPTION_HERE%3E
+
+  =============[ LINTING & STATIC ANALYSIS ]=============
+
+    - If your issue ONLY has to do with TSLint
+      
+      https://github.com/typed-ember/ember-cli-tslint/issues/new
+      
+    - Otherwise
+
+      https://github.com/typed-ember/ember-cli-typescript/issues/new?template=CONFIG_ISSUE.md&labels=%5Bconfig%5D&title=%5Bconfig%5D%20-%20-%3CYOUR_DESCRIPTION_HERE%3E
+
+  =============[ FEATURE REQUESTS ]=============
+    
+    - Relating to type information: 
+        
+      https://github.com/typed-ember/ember-cli-typescript/issues/new?template=TYPES_ENHANCEMENT.md&labels=%5Btypes%5D&title=%5B@types/ember%20enhancement%5D%20-%20%3CYOUR_DESCRIPTION_HERE%3E
+    
+    - Relating to build infrastructure:
+        
+      https://github.com/typed-ember/ember-cli-typescript/issues/new?template=BUILD_ENHANCEMENT.md&labels=%5Bbuild%5D&title=%5Benhancement%5D%20-%20%3CYOUR_DESCRIPTION_HERE%3E
+
+
+-->

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Use TypeScript in your Ember 2.x and 3.x apps!
 
 [![*nix build status (master)](https://travis-ci.org/typed-ember/ember-cli-typescript.svg?branch=master)](https://travis-ci.org/typed-ember/ember-cli-typescript) [![Windows build status](https://ci.appveyor.com/api/projects/status/i94uv7jgmrg022ho/branch/master?svg=true)](https://ci.appveyor.com/project/chriskrycho/ember-cli-typescript/branch/master) [![Ember Observer Score](https://emberobserver.com/badges/ember-cli-typescript.svg)](https://emberobserver.com/addons/ember-cli-typescript)
 
+* [Getting Help](#getting-help)
 * [Setup and Configuration](#setup-and-configuration)
   * [Ember Support](#ember-support)
   * [`tsconfig.json`](#tsconfigjson)
@@ -38,6 +39,40 @@ Use TypeScript in your Ember 2.x and 3.x apps!
   * [Some `import`s don't resolve](#some-imports-dont-resolve)
   * [Type safety when invoking actions](#type-safety-when-invoking-actions)
 
+## Getting Help
+
+When seeking help, you should first consider what you need, and which aspect of the Ember+TypeScript ecosystem your issue pertains to.
+
+### 💬 Getting Started
+
+We have an [Ember Community Slack channel](https://embercommunity.slack.com/messages/C2F8Q3SK1) where you can ask about getting started, good resources for self-directed learning and more. 
+
+### 📚 Issues With Ember Type Definitions
+
+If you've found that some of the ember type information is missing things, or is incorrect in some way, please first ensure you're using the latest version of the [packages this addon installs](#other-packages-this-addon-installs). Although [StackOverflow](https://stackoverflow.com/questions/tagged/ember.js+typescript) and [Discuss](https://discuss.emberjs.com/search?q=typescript) are not the advised places to report problems, you may find an answer there.
+
+ If you still see a problem, please create a bug report [here](https://github.com/typed-ember/ember-cli-typescript/issues/new?template=TYPES_BUG.md&labels=%5Btypes,bug%5D&title=%5B@types/ember%20bug%5D%20-%20%3CYOUR_DESCRIPTION_HERE%3E) or a feature request [here](https://github.com/typed-ember/ember-cli-typescript/issues/new?template=TYPES_ENHANCEMENT.md&labels=%5Btypes,enhancement%5D&title=%5B@types/ember%20enhancement%5D%20-%20%3CYOUR_DESCRIPTION_HERE%3E).
+
+### ⚙️ Issues With Adding TypeScript Support To Apps and Addons
+
+If you run into a problem with the way TypeScript is compiled in ember apps (i.e., a broccoli error message, incorrect build output, etc...), please first check [StackOverflow](https://stackoverflow.com/questions/tagged/ember.js+typescript) and [Discuss](https://discuss.emberjs.com/search?q=typescript), as you may find an answer.
+
+If you still need help, please open an bug report [here](https://github.com/typed-ember/ember-cli-typescript/issues/new?template=BUILD_BUG.md&labels=%5Bbuild,bug%5D&title=%5Bbug%5D%20-%20%3CYOUR_DESCRIPTION_HERE%3E) or a feature request [here](https://github.com/typed-ember/ember-cli-typescript/issues/new?template=BUILD_ENHANCEMENT.md&labels=%5Bbuild,enhancement%5D&title=%5Benhancement%5D%20-%20%3CYOUR_DESCRIPTION_HERE%3E) 
+
+### ✅ Issues With Static Analysis of TypeScript In Ember Apps and Addons
+
+The TypeScript compiler does some very basic static analysis of your code, and most developers use Palantir's TSLint tool for more thorough checking.
+
+One sure way to tell which tool is generating an error message is that *TSLint will always mention the name of the pertinent rule, when it alerts you to a violation*.
+
+##### Example: 
+```
+[tslint] variable name must be in lowerCamelCase, PascalCase or UPPER_CASE (variable-name)
+```
+`variable-name` is the name of the rule.
+
+For issues relating to typescript compiler analysis, create an issue in this repository by clicking [here](https://github.com/typed-ember/ember-cli-typescript/issues/new?template=CONFIG_ISSUE.md&labels=%5Bbuild%5D&title=%5Bconfig%5D%20-%20-%3CYOUR_DESCRIPTION_HERE%3E). For TSLint-related concerns, please create an issue in the [`ember-cli-tslint`](https://github.com/typed-ember/ember-cli-tslint) project by clicking [here](https://github.com/typed-ember/ember-cli-tslint/issues/new).
+
 ## Setup and Configuration
 
 To install or upgrade the addon, just run:
@@ -50,14 +85,18 @@ All dependencies will be added to your `package.json`, and you're ready to roll!
 
 In addition to ember-cli-typescript, we make the following changes to your project:
 
+### Other Packages This Addon Installs
+
 * We install the following packages—all at their current "latest" value—or generated:
 
   * [`typescript`](https://github.com/Microsoft/TypeScript)
-  * [`@types/ember`](https://www.npmjs.com/package/@types/ember)
-  * [`@types/ember-data`](https://www.npmjs.com/package/@types/ember-data)
-  * [`@types/rsvp`](https://www.npmjs.com/package/@types/rsvp)
-  * [`@types/ember-test-helpers`](https://www.npmjs.com/package/@types/ember-test-helpers) – these are the importable test helpers from [RFC #232](https://github.com/emberjs/rfcs/blob/master/text/0232-simplify-qunit-testing-api.md)-style tests
-  * [`@types/ember-testing-helpers`](https://www.npmjs.com/package/@types/ember-testing-helpers) – these are the globally-available acceptance test helpers
+  * **@types/ember** ([npm](https://www.npmjs.com/package/@types/ember) | [source](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/ember)) - Types for [Ember.js](https://github.com/emberjs/ember.js)
+  * **@types/ember-data** - ([npm](https://www.npmjs.com/package/@types/ember-data) | [source](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/ember-data)) - Types for [Ember-Data](https://github.com/emberjs/data)
+  * **@types/rsvp** - ([npm](https://www.npmjs.com/package/@types/rsvp) | [source](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/rsvp)) - Types for [RSVP.js](https://github.com/tildeio/rsvp.js/)
+  * **@types/ember-test-helpers** - ([npm](https://www.npmjs.com/package/@types/ember-test-helpers) | [source](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/ember-test-helpers)) Types for [ember-test-helpers](https://github.com/emberjs/ember-test-helpers), which arose from [RFC #232](https://github.com/emberjs/rfcs/blob/master/text/0232-simplify-qunit-testing-api.md)
+  * **@types/ember-testing-helpers** - ([npm](https://www.npmjs.com/package/@types/ember-testing-helpers) | [source](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/ember-testing-helpers)) – Types for [Ember's built-in globally-available test helpers](https://github.com/emberjs/ember.js/tree/master/packages/ember-testing/lib/helpers)
+
+### Files this addon Generates
 
 * We add the following files to your project:
 

--- a/README.md
+++ b/README.md
@@ -45,17 +45,17 @@ When seeking help, you should first consider what you need, and which aspect of 
 
 ### 💬 Getting Started
 
-We have an [Ember Community Slack channel](https://embercommunity.slack.com/messages/C2F8Q3SK1) where you can ask about getting started, good resources for self-directed learning and more. 
+We have an Ember Community Slack channel [#-topic-typescript](https://embercommunity.slack.com/messages/C2F8Q3SK1) where you can ask about getting started, good resources for self-directed learning and more. 
 
 ### 📚 Issues With Ember Type Definitions
 
-If you've found that some of the ember type information is missing things, or is incorrect in some way, please first ensure you're using the latest version of the [packages this addon installs](#other-packages-this-addon-installs). Although [StackOverflow](https://stackoverflow.com/questions/tagged/ember.js+typescript) and [Discuss](https://discuss.emberjs.com/search?q=typescript) are not the advised places to report problems, you may find an answer there.
+If you've found that some of the Ember type information is missing things, or is incorrect in some way, please first ensure you're using the latest version of the [packages this addon installs](#other-packages-this-addon-installs). Although [StackOverflow](https://stackoverflow.com/questions/tagged/ember.js+typescript) and [Discuss](https://discuss.emberjs.com/search?q=typescript) are not the advised places to report problems, you may find an answer there.
 
  If you still see a problem, please create a bug report [here](https://github.com/typed-ember/ember-cli-typescript/issues/new?template=TYPES_BUG.md&labels=%5Btypes,bug%5D&title=%5B@types/ember%20bug%5D%20-%20%3CYOUR_DESCRIPTION_HERE%3E) or a feature request [here](https://github.com/typed-ember/ember-cli-typescript/issues/new?template=TYPES_ENHANCEMENT.md&labels=%5Btypes,enhancement%5D&title=%5B@types/ember%20enhancement%5D%20-%20%3CYOUR_DESCRIPTION_HERE%3E).
 
 ### ⚙️ Issues With Adding TypeScript Support To Apps and Addons
 
-If you run into a problem with the way TypeScript is compiled in ember apps (i.e., a broccoli error message, incorrect build output, etc...), please first check [StackOverflow](https://stackoverflow.com/questions/tagged/ember.js+typescript) and [Discuss](https://discuss.emberjs.com/search?q=typescript), as you may find an answer.
+If you run into a problem with the way TypeScript is compiled in Ember apps (i.e., a broccoli error message, incorrect build output, etc...), please first check [StackOverflow](https://stackoverflow.com/questions/tagged/ember.js+typescript) and [Discuss](https://discuss.emberjs.com/search?q=typescript), as you may find an answer.
 
 If you still need help, please open an bug report [here](https://github.com/typed-ember/ember-cli-typescript/issues/new?template=BUILD_BUG.md&labels=%5Bbuild,bug%5D&title=%5Bbug%5D%20-%20%3CYOUR_DESCRIPTION_HERE%3E) or a feature request [here](https://github.com/typed-ember/ember-cli-typescript/issues/new?template=BUILD_ENHANCEMENT.md&labels=%5Bbuild,enhancement%5D&title=%5Benhancement%5D%20-%20%3CYOUR_DESCRIPTION_HERE%3E) 
 
@@ -63,7 +63,7 @@ If you still need help, please open an bug report [here](https://github.com/type
 
 The TypeScript compiler does some very basic static analysis of your code, and most developers use Palantir's TSLint tool for more thorough checking.
 
-One sure way to tell which tool is generating an error message is that *TSLint will always mention the name of the pertinent rule, when it alerts you to a violation*.
+One sure way to tell which tool is generating an error message is that *Linters like [TSLint](https://github.com/palantir/tslint/) and [ESLint](https://eslint.org/) will always mention their name, and the name of the pertinent rule, when it alerts you to a violation*.
 
 ##### Example: 
 ```
@@ -71,7 +71,7 @@ One sure way to tell which tool is generating an error message is that *TSLint w
 ```
 `variable-name` is the name of the rule.
 
-For issues relating to typescript compiler analysis, create an issue in this repository by clicking [here](https://github.com/typed-ember/ember-cli-typescript/issues/new?template=CONFIG_ISSUE.md&labels=%5Bbuild%5D&title=%5Bconfig%5D%20-%20-%3CYOUR_DESCRIPTION_HERE%3E). For TSLint-related concerns, please create an issue in the [`ember-cli-tslint`](https://github.com/typed-ember/ember-cli-tslint) project by clicking [here](https://github.com/typed-ember/ember-cli-tslint/issues/new).
+For issues relating to typescript compiler analysis, create an issue in this repository by clicking [here](https://github.com/typed-ember/ember-cli-typescript/issues/new?template=CONFIG_ISSUE.md&labels=%5Bbuild%5D&title=%5Bconfig%5D%20-%20-%3CYOUR_DESCRIPTION_HERE%3E). For TSLint-related concerns, please create an issue in the [`ember-cli-tslint`](https://github.com/typed-ember/ember-cli-tslint) project by clicking [here](https://github.com/typed-ember/ember-cli-tslint/issues/new). If you run into issues with using ESLint with Ember, create an issue [here](https://github.com/ember-cli/ember-cli-eslint/issues/new).
 
 ## Setup and Configuration
 


### PR DESCRIPTION
This adds some clear information at the top of the README to help people with issues find the correct place to get help.

- [x] Someone with a commit bit should also create issue labels: `types` and `build` (`enhancement` and `bug` already exist by default) so that issues are auto-tagged depending on the link they click.

