### PR TITLE
Fix addon order for generators when usign ember-decorators

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,8 @@
     ],
     "after": [
       "ember-source",
-      "ember-data"
+      "ember-data",
+      "ember-decorators"
     ],
     "paths": [
       "tests/dummy/lib/in-repo-a",


### PR DESCRIPTION
When using `ember-decorators` project in combination with typescript, the generators from the decorators was taking precedence of the generators from typescript. This fixes it.

This might fix #233.