### PR TITLE
@ember/test-helpers definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ In addition to ember-cli-typescript, we make the following changes to your proje
   * **@types/rsvp** - ([npm](https://www.npmjs.com/package/@types/rsvp) | [source](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/rsvp)) - Types for [RSVP.js](https://github.com/tildeio/rsvp.js/)
   * **@types/ember-test-helpers** - ([npm](https://www.npmjs.com/package/@types/ember-test-helpers) | [source](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/ember-test-helpers)) Types for [ember-test-helpers](https://github.com/emberjs/ember-test-helpers), which arose from [RFC #232](https://github.com/emberjs/rfcs/blob/master/text/0232-simplify-qunit-testing-api.md)
   * **@types/ember-testing-helpers** - ([npm](https://www.npmjs.com/package/@types/ember-testing-helpers) | [source](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/ember-testing-helpers)) – Types for [Ember's built-in globally-available test helpers](https://github.com/emberjs/ember.js/tree/master/packages/ember-testing/lib/helpers)
+  * **@types/ember__test-helpers** - ([npm](https://www.npmjs.com/package/@types/ember__test-helpers) | [source](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/ember__test-helpers)) – Types for [ember-test-helpers](https://github.com/emberjs/ember-test-helpers) when imported as `@ember/test-helpers`.
 
 ### Files this addon Generates
 

--- a/blueprints/ember-cli-typescript/index.js
+++ b/blueprints/ember-cli-typescript/index.js
@@ -102,6 +102,7 @@ module.exports = {
       { name: '@types/rsvp', target: 'latest' },
       { name: '@types/ember-test-helpers', target: 'latest' },
       { name: '@types/ember-testing-helpers', target: 'latest' },
+      { name: '@types/ember__test-helpers', target: 'latest' },
     ];
 
     if (this._has('ember-data')) {


### PR DESCRIPTION
I mentioned this in Slack, and I figured that I ought to just do it and you can decide here if if works for you.

It adds a blueprint to create a definition for `@ember/test-helpers` in the `types` folder. It also adds a line about said file in the readme.

