### PR TITLE
Use devDependencies for in-repo dummy addons.

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,9 @@
     "eslint-plugin-ember": "^5.0.3",
     "eslint-plugin-node": "^6.0.1",
     "esprima": "^4.0.0",
+    "in-repo-a": "link:tests/dummy/lib/in-repo-a",
+    "in-repo-b": "link:tests/dummy/lib/in-repo-b",
+    "in-repo-c": "link:tests/dummy/lib/in-repo-c",
     "loader.js": "^4.2.3",
     "mktemp": "^0.4.0",
     "mocha": "^5.0.0",
@@ -97,11 +100,6 @@
     "configPath": "tests/dummy/config",
     "before": [
       "ember-cli-babel"
-    ],
-    "paths": [
-      "tests/dummy/lib/in-repo-a",
-      "tests/dummy/lib/in-repo-b",
-      "tests/dummy/lib/in-repo-c"
     ]
   },
   "prettier": {

--- a/tests/dummy/lib/in-repo-a/package.json
+++ b/tests/dummy/lib/in-repo-a/package.json
@@ -1,10 +1,11 @@
 {
   "name": "in-repo-a",
+  "version": "1.0.0",
   "keywords": [
     "ember-addon"
   ],
   "dependencies": {
-    "ember-cli-babel": "*"
+    "ember-cli-babel": "link:../../../../node_modules/ember-cli-babel"
   },
   "devDependencies": {
     "ember-cli-typescript": "*"

--- a/tests/dummy/lib/in-repo-b/package.json
+++ b/tests/dummy/lib/in-repo-b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "in-repo-b",
+  "version": "1.0.0",
   "keywords": [
     "ember-addon"
   ],
   "dependencies": {
-    "ember-cli-babel": "*"
+    "ember-cli-babel": "link:../../../../node_modules/ember-cli-babel"
   },
   "devDependencies": {
     "ember-cli-typescript": "*"

--- a/tests/dummy/lib/in-repo-c/package.json
+++ b/tests/dummy/lib/in-repo-c/package.json
@@ -1,10 +1,11 @@
 {
   "name": "in-repo-c",
+  "version": "1.0.0",
   "keywords": [
     "ember-addon"
   ],
   "dependencies": {
-    "ember-cli-babel": "*"
+    "ember-cli-babel": "link:../../../../node_modules/ember-cli-babel"
   },
   "devDependencies": {
     "ember-cli-typescript": "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2488,6 +2488,10 @@ ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6
     ember-cli-version-checker "^2.1.0"
     semver "^5.4.1"
 
+"ember-cli-babel@link:node_modules/ember-cli-babel":
+  version "0.0.0"
+  uid ""
+
 ember-cli-blueprint-test-helpers@^0.18.3:
   version "0.18.3"
   resolved "https://registry.yarnpkg.com/ember-cli-blueprint-test-helpers/-/ember-cli-blueprint-test-helpers-0.18.3.tgz#945c606d855f0263f5e8c03522e4040a74f259cc"
@@ -4119,6 +4123,18 @@ ignore@^3.3.3, ignore@^3.3.6:
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
+
+"in-repo-a@link:tests/dummy/lib/in-repo-a":
+  version "0.0.0"
+  uid ""
+
+"in-repo-b@link:tests/dummy/lib/in-repo-b":
+  version "0.0.0"
+  uid ""
+
+"in-repo-c@link:tests/dummy/lib/in-repo-c":
+  version "0.0.0"
+  uid ""
 
 indent-string@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
This was raised in Discord — the new PackageInfoCache stuff in ember-cli@3.4 complains loudly about missing packages in our published `paths` entry.

```
WARNING:
WARNING: /Users/jasonevans/projects/open-x/node_modules/ember-cli-typescript/tests/dummy/lib/in-repo-a:
WARNING:    Missing package directory
WARNING:
WARNING: /Users/jasonevans/projects/open-x/node_modules/ember-cli-typescript/tests/dummy/lib/in-repo-b:
WARNING:    Missing package directory
WARNING:
WARNING: /Users/jasonevans/projects/open-x/node_modules/ember-cli-typescript/tests/dummy/lib/in-repo-c:
WARNING:    Missing package directory
WARNING:
WARNING: /Users/jasonevans/projects/open-x/node_modules/simple-html-tokenizer/commands:
WARNING:    Missing package directory
WARNING: For addon at path /Users/jasonevans/projects/open-x/node_modules/ember-cli-typescript:
WARNING:    Excluding invalid/malformed/missing addon at relative path 'tests/dummy/lib/in-repo-a'
WARNING:    Excluding invalid/malformed/missing addon at relative path 'tests/dummy/lib/in-repo-b'
WARNING:    Excluding invalid/malformed/missing addon at relative path 'tests/dummy/lib/in-repo-c'
```

Making them `link:` `devDependencies` instead should eliminate any references for downstream consumers.