### PR TITLE
[bugfix] Ensure TS blueprints are always used

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,18 +9,6 @@ const stew = require('broccoli-stew');
 module.exports = {
   name: 'ember-cli-typescript',
 
-  init() {
-    this._super.init.apply(this, arguments);
-
-    // If we're a direct dependency of the app, we cheat and add our instance of the blueprints
-    // addon to the project, as only top-level addons contribute blueprints.
-    // This won't be necessary in 2.x if we shift to adding the blueprints addon as a host
-    // dependency on install.
-    if (this.project.addons.includes(this)) {
-      this.project.addons.push(this.addons.find(addon => addon.name === 'ember-cli-typescript-blueprints'));
-    }
-  },
-
   included(includer) {
     this._super.included.apply(this, arguments);
 
@@ -31,6 +19,16 @@ module.exports = {
   },
 
   includedCommands() {
+    // If we're a direct dependency of the app, we cheat and add our instance of the blueprints
+    // addon to the project, as only top-level addons contribute blueprints. We need to be careful
+    // with the timing of when we do this, as it has to happen after addon initialization is
+    // complete, but before blueprint paths are resolved.
+    // This won't be necessary in 2.x if we shift to adding the blueprints addon as a host
+    // dependency on install.
+    if (this.project.addons.includes(this)) {
+      this.project.addons.push(this.addons.find(addon => addon.name === 'ember-cli-typescript-blueprints'));
+    }
+
     if (this.project.isEmberCLIAddon()) {
       return {
         'ts:precompile': require('./lib/commands/precompile'),

--- a/node-tests/blueprints/packaged-blueprints-test.js
+++ b/node-tests/blueprints/packaged-blueprints-test.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const blueprintHelpers = require('ember-cli-blueprint-test-helpers/helpers');
+const setupTestHooks = blueprintHelpers.setupTestHooks;
+const emberNew = blueprintHelpers.emberNew;
+const emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
+
+const expect = require('ember-cli-blueprint-test-helpers/chai').expect;
+
+describe('Acceptance: TypeScript blueprints', function() {
+  setupTestHooks(this);
+
+  it('uses blueprints from ember-cli-typescript-blueprints', function() {
+    let args = ['helper', 'foo'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, (file) => {
+        const generated = file('app/helpers/foo.ts');
+        expect(generated).to.contain('export function foo');
+        expect(generated).to.contain('export default helper(foo)');
+    }));
+  });
+});


### PR DESCRIPTION
This should be a quick 1.4.2 fix on the heels of 1.4.1 that just went out. It turns out `init` is not a safe place to do our `project.addons` munging, and ember-cli really isn't set up to make it simple to expose blueprints from another addon while also having your own. The 1.4.1 release that just went out doesn't consistently emit `.ts` files from `embebr generate`.

Essentially:
 - we can't sneak in the blueprints addon in `init`, because the project's own `addons` array is set _after_ all its addons have been initialized
 - we can't sneak in an additional `blueprintsPath` value because we need to also include our own, and every addon is allowed to return at most one
 - the `includedCommands` hook is a convenient (if unfortunate) spot for us to use, as we know the addons will already have been initialized (so `project.addons` is populated) but it has to execute before blueprint paths are actually resolved (available commands are all loaded before any one is executed)

I've also added a test case to ensure this continues working with future releases of the CLI (though the codepaths involved have been pretty stable for some time). This isn't a beautiful solution, but I'm hoping to focus efforts on moving to 2.0 where we won't need to do this at all.