### PR TITLE
fix: clean up system temp directory when running.

### DIFF
--- a/ts/lib/incremental-typescript-compiler/index.js
+++ b/ts/lib/incremental-typescript-compiler/index.js
@@ -117,6 +117,8 @@ module.exports = class IncrementalTypescriptCompiler {
   outDir() {
     if (!this._outDir) {
       let outDir = path.join(tmpdir(), `e-c-ts-${process.pid}`);
+      fs.removeSync(outDir);
+
       this._outDir = outDir;
       fs.mkdirsSync(outDir);
     }


### PR DESCRIPTION
While the system temp directory gets cleaned up semi-regularly, on long-running machines (e.g. CI servers), it is possible for the PID to get reused before the system temp directory gets cleared. When this happens, the temp directory we create as an intermediate location for TypeScript build artifacts (to prevent churn in the build) can end up being used for multiple builds, even across separate apps. This can result in very bad output from the build, including total runtime failures from things like `require` entries including files from different builds or apps.

Prevent this by always running `fs.removeSync` on the temp output directory prior to setting it and putting new output there.

Fixes #318.