### PR TITLE
[v2] Install ember-cli-typescript-blueprints by default in the host

### DIFF
--- a/ts/blueprints/ember-cli-typescript/index.js
+++ b/ts/blueprints/ember-cli-typescript/index.js
@@ -28,7 +28,6 @@ module.exports = {
   },
 
   locals() {
-    let updatePathsForAddon = require('ember-cli-typescript-blueprints/lib/utilities/update-paths-for-addon');
     let inRepoAddons = (this.project.pkg['ember-addon'] || {}).paths || [];
     let hasMirage = 'ember-cli-mirage' in (this.project.pkg.devDependencies || {});
     let isAddon = this.project.isEmberCLIAddon();
@@ -48,6 +47,8 @@ module.exports = {
     return {
       includes: JSON.stringify(includes.map(include => `${include}/**/*`), null, 2).replace(/\n/g, '\n  '),
       pathsFor: dasherizedName => {
+        // We need to wait to use this module until `ember-cli-typescript-blueprints` has been installed
+        let updatePathsForAddon = require('ember-cli-typescript-blueprints/lib/utilities/update-paths-for-addon');
         let appName = isAddon ? 'dummy' : dasherizedName;
         let paths = {
           [`${appName}/tests/*`]: ['tests/*'],
@@ -118,14 +119,13 @@ module.exports = {
     // Entity name is optional right now, creating this hook avoids an error.
   },
 
-  afterInstall() {
+  beforeInstall() {
     if (this.project.isEmberCLIAddon()) {
       this._installPrecompilationHooks();
     }
 
     let packages = [
-      // TODO release blueprints@2 that emit `.js` files in `app/`
-      // { name: 'ember-cli-typescript-blueprints', target: '^2.0.0' },
+      { name: 'ember-cli-typescript-blueprints', target: '^2.0.0-beta.1' },
       { name: 'typescript', target: 'latest' },
       { name: '@types/ember', target: 'latest' },
       { name: '@types/rsvp', target: 'latest' },

--- a/ts/tests/blueprints/ember-cli-typescript-test.js
+++ b/ts/tests/blueprints/ember-cli-typescript-test.js
@@ -53,6 +53,7 @@ describe('Acceptance: ember-cli-typescript generator', function() {
         const pkgJson = JSON.parse(pkg.content);
         expect(pkgJson.scripts.prepublishOnly).to.be.undefined;
         expect(pkgJson.scripts.postpublish).to.be.undefined;
+        expect(pkgJson.devDependencies).to.include.all.keys('ember-cli-typescript-blueprints');
         expect(pkgJson.devDependencies).to.include.all.keys('ember-data');
         expect(pkgJson.devDependencies).to.include.all.keys('@types/ember-data');
         expect(pkgJson.devDependencies).to.include.all.keys('ember-qunit');


### PR DESCRIPTION
Now that we no longer depend on the blueprints package directly, the host needs to have it added on installation.