### PR TITLE
Ensure we don't break transpilation parallelizability

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -4,6 +4,9 @@ const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
   let app = new EmberAddon(defaults, {
+    'ember-cli-babel': {
+      throwUnlessParallelizable: true
+    },
     babel: {
       sourceMaps: 'inline'
     }

--- a/ts/addon.ts
+++ b/ts/addon.ts
@@ -1,7 +1,7 @@
 import semver from 'semver';
 import { Remote } from 'stagehand';
 import { connect } from 'stagehand/lib/adapters/child-process';
-import { hasPlugin, addPlugin, AddPluginOptions } from 'ember-cli-babel-plugin-helpers';
+import { hasPlugin, addPlugin, AddPluginOptions, BabelPluginConfig } from 'ember-cli-babel-plugin-helpers';
 import Addon from 'ember-cli/lib/models/addon';
 import { addon } from './lib/utilities/ember-cli-entities';
 import fork from './lib/utilities/fork';
@@ -109,7 +109,9 @@ export default addon({
     let target = this._getConfigurationTarget();
 
     if (!hasPlugin(target, name)) {
-      addPlugin(target, [require.resolve(name), config], constraints);
+      let resolvedPath = require.resolve(name);
+      let pluginEntry: BabelPluginConfig = config ? [resolvedPath, config] : resolvedPath;
+      addPlugin(target, pluginEntry, constraints);
     }
   },
 


### PR DESCRIPTION
From https://github.com/emberjs/data/pull/5647/files#r228593401

Prior to this we were configuring the TypeScript Babel plugin as `[pluginPath]`, but `broccoli-babel-transpiler` assumes if you specify an array that you intend to include a second configuration parameter, and `undefined` isn't a JSON-serializable value.