### PR TITLE
Update README for v2 `ember install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ For issues relating to typescript compiler analysis, [create an issue in this pr
 To install or upgrade the addon, just run:
 
 ```
-ember install ember-cli-typescript@latest
+ember install ember-cli-typescript@latest --save
 ```
 
 All dependencies will be added to your `package.json`, and you're ready to roll! If you're upgrading from a previous release, you should check to merge any tweaks you've made to `tsconfig.json`.


### PR DESCRIPTION
v2 won't function properly unless set up as a `dependency`. ember-cli installs packages as `devDependency` by default (the correct default imo).

This updates the readme to clarify how the code on master should be installed into apps.