### PR TITLE
[v2] Don't make assumptions about what files will trigger a typecheck

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@types/chai": "4.1.7",
     "@types/console-ui": "2.2.0",
     "@types/core-object": "3.0.0",
+    "@types/debug": "^0.0.31",
     "@types/ember": "3.0.25",
     "@types/ember-qunit": "3.4.3",
     "@types/execa": "0.9.0",

--- a/ts/tests/acceptance/build-test.js
+++ b/ts/tests/acceptance/build-test.js
@@ -65,6 +65,16 @@ describe('Acceptance: build', function() {
     expect(output).to.include(`Cannot find module 'nonexistent'`);
     expect(response.body).to.include(`Cannot find module 'nonexistent'`);
   }));
+
+  it("doesn't block builds for file changes that don't result in a typecheck", co.wrap(function*() {
+    let server = this.app.serve();
+
+    yield server.waitForBuild();
+
+    this.app.writeFile('app/some-template.hbs', '');
+
+    yield server.waitForBuild();
+  }));
 });
 
 function extractModuleBody(script, moduleName) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -704,6 +704,11 @@
   resolved "https://registry.yarnpkg.com/@types/core-object/-/core-object-3.0.0.tgz#3c7a9ff732dd5a66a09860c4a134751d7abd11a2"
   integrity sha512-SYM//l00O/LXbT0GqTaonlYQubkXDWyfOEpzEehiedtF+wEJCliP4G05/2tM+bulFNgqnBG4uRRe8k/HGQUA3A==
 
+"@types/debug@^0.0.31":
+  version "0.0.31"
+  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-0.0.31.tgz#bac8d8aab6a823e91deb7f79083b2a35fa638f33"
+  integrity sha512-LS1MCPaQKqspg7FvexuhmDbWUhE2yIJ+4AgVIyObfc06/UKZ8REgxGNjZc82wPLWmbeOm7S+gSsLgo75TanG4A==
+
 "@types/ember-qunit@3.4.3":
   version "3.4.3"
   resolved "https://registry.yarnpkg.com/@types/ember-qunit/-/ember-qunit-3.4.3.tgz#ad8532e735c7a46af764f5cb7d852896e6d28bfd"
@@ -6045,9 +6050,11 @@ imurmurhash@^0.1.4:
 
 "in-repo-a@link:tests/dummy/lib/in-repo-a":
   version "0.0.0"
+  uid ""
 
 "in-repo-b@link:tests/dummy/lib/in-repo-b":
   version "0.0.0"
+  uid ""
 
 indent-string@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
@chriskrycho and I spent some time talking through this one yesterday.

When a project file changes, we have to make a decision about whether we expect that change to result in a typecheck or not. Today, we assume that anything with a `.ts` extension will produce a typecheck, and anything else (e.g. `.hbs` and `.css` files) will not.

However, it can actually happen that a `.ts` file changes and doesn't produce a new typecheck, e.g. when a declaration file changes that `tsc` has already determined is irrelevant to the overall correctness of the build. In such cases, we'll hang indefinitely as we wait for a new check result that's never going to come.

This updates the typecheck worker to treat FS events as having the _potential_ to result in a typecheck, either confirming or settling back to the previous state depending on whether one is ultimately kicked off. This means we no longer have to make assumptions about what file extensions will trigger a check, and can instead rely on observed behavior.