### PR TITLE
[v2] Check off a couple remaining todo items

### DIFF
--- a/blueprint-files/ember-cli-typescript/tsconfig.json
+++ b/blueprint-files/ember-cli-typescript/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "es2017",
     "allowJs": true,
     "moduleResolution": "node",
+    "isolatedModules": true,
     "allowSyntheticDefaultImports": true,
     "noImplicitAny": true,
     "noImplicitThis": true,

--- a/ts/addon.ts
+++ b/ts/addon.ts
@@ -14,7 +14,7 @@ export default addon({
   included() {
     this._super.included.apply(this, arguments);
     this._checkDevelopment();
-    this._checkBabelVersion();
+    this._checkPeerVersions();
 
     // If we're a direct dependency of the host app, go ahead and start up the
     // typecheck worker so we don't wait until the end of the build to check
@@ -87,7 +87,7 @@ export default addon({
     return !['in-repo-a', 'in-repo-b'].includes(addon.name);
   },
 
-  _checkBabelVersion() {
+  _checkPeerVersions() {
     let babel = this.parent.addons.find(addon => addon.name === 'ember-cli-babel');
     let version = babel && babel.pkg.version;
     if (!babel || !(semver.gte(version!, '7.1.0') && semver.lt(version!, '8.0.0'))) {
@@ -95,6 +95,15 @@ export default addon({
       this.ui.writeWarnLine(
         `ember-cli-typescript requires ember-cli-babel ^7.1.0, but you have ${versionString} installed; ` +
           'your TypeScript files may not be transpiled correctly.'
+      );
+    }
+
+    let cliPackage = this.project.require('ember-cli/package.json') as { version: string };
+    if (semver.lt(cliPackage.version, '3.5.0')) {
+      this.ui.writeWarnLine(
+        'ember-cli-typescript works best with ember-cli >= 3.5, which uses the system temporary directory ' +
+          'by default rather than a project-local one, minimizing file system events the TypeScript ' +
+          'compiler needs to keep track of.'
       );
     }
   },

--- a/ts/tests/blueprints/ember-cli-typescript-test.js
+++ b/ts/tests/blueprints/ember-cli-typescript-test.js
@@ -72,6 +72,7 @@ describe('Acceptance: ember-cli-typescript generator', function() {
 
         expect(tsconfigJson.compilerOptions.inlineSourceMap).to.equal(true);
         expect(tsconfigJson.compilerOptions.inlineSources).to.equal(true);
+        expect(tsconfigJson.compilerOptions.isolatedModules).to.equal(true);
 
         expect(tsconfigJson.include).to.deep.equal(['app/**/*', 'tests/**/*', 'types/**/*']);
 


### PR DESCRIPTION
- Include `isolatedModules: true` in the default `tsconfig.json` as [recommended by Microsoft when transpiling with Babel](https://blogs.msdn.microsoft.com/typescript/2018/08/27/typescript-and-babel-7/)
- Warn when we detect ember-cli < 3.5, because project-local `tmp` can upset `tsc`