### PR TITLE
fix: include typechecking middleware in test mode

### DIFF
--- a/ts/addon.ts
+++ b/ts/addon.ts
@@ -7,6 +7,7 @@ import { addon } from './lib/utilities/ember-cli-entities';
 import fork from './lib/utilities/fork';
 import TypecheckWorker from './lib/typechecking/worker';
 import TypecheckMiddleware from './lib/typechecking/middleware';
+import { Application } from 'express';
 
 export default addon({
   name: 'ember-cli-typescript',
@@ -37,9 +38,11 @@ export default addon({
   },
 
   serverMiddleware({ app }) {
-    let workerPromise = this._getTypecheckWorker();
-    let middleware = new TypecheckMiddleware(this.project, workerPromise);
-    middleware.register(app);
+    this._addTypecheckMiddleware(app);
+  },
+
+  testemMiddleware(app) {
+    this._addTypecheckMiddleware(app);
   },
 
   async postBuild() {
@@ -143,6 +146,12 @@ export default addon({
     if (!extensions.includes('ts')) {
       extensions.push('ts');
     }
+  },
+
+  _addTypecheckMiddleware(app: Application) {
+    let workerPromise = this._getTypecheckWorker();
+    let middleware = new TypecheckMiddleware(this.project, workerPromise);
+    middleware.register(app);
   },
 
   _typecheckWorker: undefined as Promise<Remote<TypecheckWorker>> | undefined,

--- a/ts/types/ember-cli/index.d.ts
+++ b/ts/types/ember-cli/index.d.ts
@@ -36,6 +36,7 @@ declare module 'ember-cli/lib/models/addon' {
     shouldIncludeChildAddon(addon: Addon): boolean;
     isDevelopingAddon(): boolean;
     serverMiddleware(options: { app: Application }): void | Promise<void>;
+    testemMiddleware(app: Application): void;
     setupPreprocessorRegistry(type: 'self' | 'parent', registry: unknown): void;
   }
 }


### PR DESCRIPTION
This isn't _super_ helpful given Ember CLI's behavior around build errors when testing today—it doesn't reload the tests page when the build fails.

It's better than nothing at all, though (users will see the type error if they manually refresh), and it situates us to be doing the right thing if the upstream behavior is fixed in the future.