### PR TITLE
fix(precompilation): specify `--isolatedModules false`

### DIFF
--- a/ts/lib/commands/precompile.ts
+++ b/ts/lib/commands/precompile.ts
@@ -28,6 +28,7 @@ export default command({
       '--allowJs', 'false',
       '--noEmit', 'false',
       '--rootDir', rootDir || this.project.root,
+      '--isolatedModules', 'false',
       '--declaration',
       '--declarationDir', outDir,
       '--emitDeclarationOnly',


### PR DESCRIPTION
Fixes #481. The tests only run on `v2` when it doesn't have a pending merge conflict with `master`, and running renovate on both branches keeps that almost perpetually the case. Fortunately we shouldn't have to stay in this state much longer.