### PR TITLE
Add blueprint support for ember-mocha

### DIFF
--- a/ts/blueprints/ember-cli-typescript/index.js
+++ b/ts/blueprints/ember-cli-typescript/index.js
@@ -147,7 +147,7 @@ module.exports = {
       ]);
     }
 
-    if (this._has('ember-cli-mocha')) {
+    if (this._has('ember-cli-mocha') || this._has('ember-mocha')) {
       packages = packages.concat([
         { name: '@types/ember-mocha', target: 'latest' },
         { name: '@types/mocha', target: 'latest' },

--- a/ts/tests/blueprints/ember-cli-typescript-test.js
+++ b/ts/tests/blueprints/ember-cli-typescript-test.js
@@ -366,43 +366,85 @@ describe('Acceptance: ember-cli-typescript generator', function() {
       });
   });
 
-  it('app with Mocha', function() {
-    const args = ['ember-cli-typescript'];
+  describe('ember-mocha', function() {
+    it('app with ember-cli-mocha', function() {
+      const args = ['ember-cli-typescript'];
 
-    return helpers
-      .emberNew()
-      .then(() => helpers.modifyPackages([
-        { name: 'ember-cli-mocha', dev: true },
-        { name: 'ember-qunit', delete: true }
-      ]))
-      .then(() => helpers.emberGenerate(args))
-      .then(() => {
-        const pkg = file('package.json');
-        expect(pkg).to.exist;
+      return helpers
+        .emberNew()
+        .then(() => helpers.modifyPackages([
+          { name: 'ember-cli-mocha', dev: true },
+          { name: 'ember-qunit', delete: true }
+        ]))
+        .then(() => helpers.emberGenerate(args))
+        .then(() => {
+          const pkg = file('package.json');
+          expect(pkg).to.exist;
 
-        const pkgJson = JSON.parse(pkg.content);
-        expect(pkgJson.devDependencies).to.include.all.keys('@types/ember-mocha', '@types/mocha');
-        expect(pkgJson.devDependencies).to.not.have.any.keys('@types/ember-qunit', '@types/qunit');
-      });
-  });
+          const pkgJson = JSON.parse(pkg.content);
+          expect(pkgJson.devDependencies).to.include.all.keys('@types/ember-mocha', '@types/mocha');
+          expect(pkgJson.devDependencies).to.not.have.any.keys('@types/ember-qunit', '@types/qunit');
+        });
+    });
 
-  it('addon with Mocha', function() {
-    const args = ['ember-cli-typescript'];
+    it('app with ember-mocha', function() {
+      const args = ['ember-cli-typescript'];
 
-    return helpers
-      .emberNew({ target: 'addon' })
-      .then(() => helpers.modifyPackages([
-        { name: 'ember-cli-mocha', dev: true },
-        { name: 'ember-qunit', delete: true }
-      ]))
-      .then(() => helpers.emberGenerate(args))
-      .then(() => {
-        const pkg = file('package.json');
-        expect(pkg).to.exist;
+      return helpers
+        .emberNew()
+        .then(() => helpers.modifyPackages([
+          { name: 'ember-mocha', dev: true },
+          { name: 'ember-qunit', delete: true }
+        ]))
+        .then(() => helpers.emberGenerate(args))
+        .then(() => {
+          const pkg = file('package.json');
+          expect(pkg).to.exist;
 
-        const pkgJson = JSON.parse(pkg.content);
-        expect(pkgJson.devDependencies).to.include.all.keys('@types/ember-mocha', '@types/mocha');
-        expect(pkgJson.devDependencies).to.not.have.any.keys('@types/ember-qunit', '@types/qunit');
-      });
+          const pkgJson = JSON.parse(pkg.content);
+          expect(pkgJson.devDependencies).to.include.all.keys('@types/ember-mocha', '@types/mocha');
+          expect(pkgJson.devDependencies).to.not.have.any.keys('@types/ember-qunit', '@types/qunit');
+        });
+    });
+
+    it('addon with ember-cli-mocha', function() {
+      const args = ['ember-cli-typescript'];
+
+      return helpers
+        .emberNew({ target: 'addon' })
+        .then(() => helpers.modifyPackages([
+          { name: 'ember-cli-mocha', dev: true },
+          { name: 'ember-qunit', delete: true }
+        ]))
+        .then(() => helpers.emberGenerate(args))
+        .then(() => {
+          const pkg = file('package.json');
+          expect(pkg).to.exist;
+
+          const pkgJson = JSON.parse(pkg.content);
+          expect(pkgJson.devDependencies).to.include.all.keys('@types/ember-mocha', '@types/mocha');
+          expect(pkgJson.devDependencies).to.not.have.any.keys('@types/ember-qunit', '@types/qunit');
+        });
+    });
+
+    it('addon with ember-mocha', function() {
+      const args = ['ember-cli-typescript'];
+
+      return helpers
+        .emberNew({ target: 'addon' })
+        .then(() => helpers.modifyPackages([
+          { name: 'ember-mocha', dev: true },
+          { name: 'ember-qunit', delete: true }
+        ]))
+        .then(() => helpers.emberGenerate(args))
+        .then(() => {
+          const pkg = file('package.json');
+          expect(pkg).to.exist;
+
+          const pkgJson = JSON.parse(pkg.content);
+          expect(pkgJson.devDependencies).to.include.all.keys('@types/ember-mocha', '@types/mocha');
+          expect(pkgJson.devDependencies).to.not.have.any.keys('@types/ember-qunit', '@types/qunit');
+        });
+    });
   });
 });


### PR DESCRIPTION
Bring blueprints on par with ember-cli-qunit/ember-qunit, supporting ember-mocha, which will supercede ember-cli-mocha.