### PR TITLE
fix: warn when addons under development have .ts files in app/

### DIFF
--- a/ts/addon.ts
+++ b/ts/addon.ts
@@ -8,6 +8,8 @@ import fork from './lib/utilities/fork';
 import TypecheckWorker from './lib/typechecking/worker';
 import TypecheckMiddleware from './lib/typechecking/middleware';
 import { Application } from 'express';
+import walkSync from 'walk-sync';
+import fs from 'fs-extra';
 
 export default addon({
   name: 'ember-cli-typescript',
@@ -16,6 +18,7 @@ export default addon({
     this._super.included.apply(this, arguments);
     this._checkDevelopment();
     this._checkPeerVersions();
+    this._checkAddonAppFiles();
 
     // If we're a direct dependency of the host app, go ahead and start up the
     // typecheck worker so we don't wait until the end of the build to check
@@ -118,6 +121,27 @@ export default addon({
         'ember-cli-typescript is in development but not being loaded from `.ts` sources — ' +
           'do you have compiled artifacts lingering in `/js`?'
       );
+    }
+  },
+
+  _checkAddonAppFiles() {
+    // Emit a warning for addons that are under active development...
+    let isDevelopingAddon = !this.app && (this.parent as Addon).isDevelopingAddon();
+
+    // ...and are at the root of the project (i.e. not in-repo)...
+    let isRootAddon = this.parent.root === this.project.root;
+
+    // ...and have .ts files in their `app` directory.
+    let appDir = `${this.parent.root}/app`;
+    if (isDevelopingAddon && isRootAddon && fs.existsSync(appDir)) {
+      let tsFilesInApp = walkSync(appDir, { globs: ['**/*.ts'] });
+      if (tsFilesInApp.length) {
+        this.ui.writeWarnLine(
+          `found .ts files in ${appDir}\n` +
+          'ember-cli-typescript only compiles files in an addon\'s `addon` folder; ' +
+          'see https://github.com/typed-ember/ember-cli-typescript/issues/562'
+        );
+      }
     }
   },
 

--- a/ts/addon.ts
+++ b/ts/addon.ts
@@ -17,7 +17,7 @@ export default addon({
   included() {
     this._super.included.apply(this, arguments);
     this._checkDevelopment();
-    this._checkAddonAppFiles();y
+    this._checkAddonAppFiles();
     this._checkBabelVersion();
 
     // If we're a direct dependency of the host app, go ahead and start up the


### PR DESCRIPTION
Closes #562. This doesn't change the underlying behavior, but it should give addon authors a heads up in cases where they're likely to run into it. Notably, the warning isn't emitted for in-repo addons, since their host typically has ember-cli-typescript set up as well, so their app trees will be processed.