### PR TITLE
fix: only warn about ember-cli version when running on the host app

### DIFF
--- a/ts/addon.ts
+++ b/ts/addon.ts
@@ -15,13 +15,14 @@ export default addon({
   included() {
     this._super.included.apply(this, arguments);
     this._checkDevelopment();
-    this._checkPeerVersions();
+    this._checkBabelVersion();
 
     // If we're a direct dependency of the host app, go ahead and start up the
     // typecheck worker so we don't wait until the end of the build to check
     if (this.parent === this.project) {
       this._getTypecheckWorker();
       this._checkInstallationLocation();
+      this._checkEmberCLIVersion();
     }
   },
 
@@ -91,7 +92,7 @@ export default addon({
     return !['in-repo-a', 'in-repo-b'].includes(addon.name);
   },
 
-  _checkPeerVersions() {
+  _checkBabelVersion() {
     let babel = this.parent.addons.find(addon => addon.name === 'ember-cli-babel');
     let version = babel && babel.pkg.version;
     if (!babel || !(semver.gte(version!, '7.1.0') && semver.lt(version!, '8.0.0'))) {
@@ -101,7 +102,9 @@ export default addon({
           'your TypeScript files may not be transpiled correctly.'
       );
     }
+  },
 
+  _checkEmberCLIVersion() {
     let cliPackage = this.project.require('ember-cli/package.json') as { version: string };
     if (semver.lt(cliPackage.version, '3.5.0')) {
       this.ui.writeWarnLine(


### PR DESCRIPTION
Prior to this, if an addon using the 2.0 RC was installed in an app on Ember CLI < 3.5, the app's build would emit a warning, even though there would be no problem, since we're not actually running `tsc`.