### PR TITLE
Remove resolutions rule for '@types/handlebars'.

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,8 @@
     "typescript-eslint-parser": "21.0.2"
   },
   "resolutions": {
-    "@types/ember": "3.0.28"
+    "@types/ember": "3.0.28",
+    "@types/ember__string": "3.0.6"
   },
   "engines": {
     "node": "6.* || 8.* || >= 10.*"

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@types/console-ui": "2.2.0",
     "@types/core-object": "3.0.0",
     "@types/debug": "4.1.1",
-    "@types/ember": "3.0.27",
+    "@types/ember": "3.0.28",
     "@types/ember-qunit": "3.4.5",
     "@types/execa": "0.9.0",
     "@types/express": "4.16.1",
@@ -111,8 +111,7 @@
     "typescript-eslint-parser": "21.0.2"
   },
   "resolutions": {
-    "@types/ember": "3.0.27",
-    "@types/handlebars": "npm:handlebars@^4.1.0"
+    "@types/ember": "3.0.28"
   },
   "engines": {
     "node": "6.* || 8.* || >= 10.*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -871,12 +871,10 @@
   dependencies:
     "@types/ember__object" "*"
 
-"@types/ember__string@*":
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/@types/ember__string/-/ember__string-3.0.5.tgz#b3b2dc872ffd6f49ac564061a9796ca8cc9ff7ca"
-  integrity sha512-pquqP3jbPsfNQ9dnJK2azOr9SSY6z0Fy2f21uuEYXmW+/1fQev/Vt55ij2PCf23AHAFBnUzhJe3sO96umHO3Xg==
-  dependencies:
-    "@types/handlebars" "*"
+"@types/ember__string@*", "@types/ember__string@3.0.6":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@types/ember__string/-/ember__string-3.0.6.tgz#79b10b0fc0136a9c86536bc55cbd18cae9a9bd3b"
+  integrity sha512-VBKH8nR/uK2tlr9eob8Nl+0cKP62GNtFWqq4PVGusnBMPFktGley1gsUhqNYJ9G3y2mvVfikicxM2/bE5AMYLA==
 
 "@types/ember__test@*":
   version "3.0.4"
@@ -920,18 +918,6 @@
   integrity sha512-w7iqhDH9mN8eLClQOYTkhdYUOSpp25eXxfc6VbFOGtzxW34JcvctH2bKjj4jD4++z4R5iO5D+pg48W2e03I65A==
   dependencies:
     "@types/node" "*"
-
-"@types/handlebars@*", handlebars@^4.0.11, handlebars@^4.0.4, handlebars@^4.1.0:
-  name handlebars
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.0.tgz#0d6a6f34ff1f63cecec8423aa4169827bf787c3a"
-  integrity sha512-l2jRuU1NAWK6AW5qqcTATWQJvNPEwkM7NEKSiv/gqOsoSQbVoWyqVEY5GS+XPQ88zLNmqASRpzfdm8d79hJS+w==
-  dependencies:
-    async "^2.5.0"
-    optimist "^0.6.1"
-    source-map "^0.6.1"
-  optionalDependencies:
-    uglify-js "^3.1.4"
 
 "@types/htmlbars-inline-precompile@*":
   version "1.0.1"
@@ -5496,6 +5482,17 @@ growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
+
+handlebars@^4.0.11, handlebars@^4.0.4, handlebars@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.0.tgz#0d6a6f34ff1f63cecec8423aa4169827bf787c3a"
+  integrity sha512-l2jRuU1NAWK6AW5qqcTATWQJvNPEwkM7NEKSiv/gqOsoSQbVoWyqVEY5GS+XPQ88zLNmqASRpzfdm8d79hJS+w==
+  dependencies:
+    async "^2.5.0"
+    optimist "^0.6.1"
+    source-map "^0.6.1"
+  optionalDependencies:
+    uglify-js "^3.1.4"
 
 har-schema@^1.0.5:
   version "1.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -753,10 +753,10 @@
     "@types/jquery" "*"
     "@types/rsvp" "*"
 
-"@types/ember@*", "@types/ember@3.0.27":
-  version "3.0.27"
-  resolved "https://registry.yarnpkg.com/@types/ember/-/ember-3.0.27.tgz#2915984038f3ae3609142f8e700b4a783a30be5d"
-  integrity sha512-amYMGBiDsqBoA/+8Hv3TFdz+pTeLbmp3EgiVVuP4AhK59ljdiigi1MBNMmOlr0u9OGDlRrK/M4DURJRWOC2KiA==
+"@types/ember@*", "@types/ember@3.0.28":
+  version "3.0.28"
+  resolved "https://registry.yarnpkg.com/@types/ember/-/ember-3.0.28.tgz#62002c34187256f7d6bf5d1245c94fbd27f7a7b0"
+  integrity sha512-1loc3Za0/8yPJWS7GxSOQL6C2wBTMGOP+srNRJWJb8L5yOikSIlmd7Rg5RYNNDN7mv7nfws5yq4JAP4HhY3ASw==
   dependencies:
     "@types/ember__application" "*"
     "@types/ember__array" "*"
@@ -773,7 +773,6 @@
     "@types/ember__string" "*"
     "@types/ember__test" "*"
     "@types/ember__utils" "*"
-    "@types/handlebars" "*"
     "@types/htmlbars-inline-precompile" "*"
     "@types/jquery" "*"
     "@types/rsvp" "*"
@@ -922,8 +921,8 @@
   dependencies:
     "@types/node" "*"
 
-"@types/handlebars@*", "@types/handlebars@npm:handlebars@^4.1.0", handlebars@^4.0.11, handlebars@^4.0.4, handlebars@^4.1.0:
-  name "handlebars"
+"@types/handlebars@*", handlebars@^4.0.11, handlebars@^4.0.4, handlebars@^4.1.0:
+  name handlebars
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.0.tgz#0d6a6f34ff1f63cecec8423aa4169827bf787c3a"
   integrity sha512-l2jRuU1NAWK6AW5qqcTATWQJvNPEwkM7NEKSiv/gqOsoSQbVoWyqVEY5GS+XPQ88zLNmqASRpzfdm8d79hJS+w==


### PR DESCRIPTION
Since the DefinitelyTyped issue which triggered the need for this hack has now been resolved, we can remove this hack. This will unblock other dependency upgrades, since the lockfile will once again work nicely.