### PR TITLE
docs: fix casing of TypeScript on the landing page

### DIFF
--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -1,9 +1,8 @@
 <DocsHeader @prefix='Ember CLI' @name='TypeScript' />
 
 <DocsHero
-  @logo='ember'
   @prefix='Ember CLI'
-  @strongHeading='TypeScript'
+  @heading='TypeScript'
   @byline='Use TypeScript in your Ember 2.x and 3.x apps!'
 />
 


### PR DESCRIPTION
The arguments to `DocsHero` changed (in 0.6, I think), and it turns out AddonDocs was just inferring the value we wanted there from the name of the addon (which was allllmost what we wanted)