### PR TITLE
Types for compiled template modules

### DIFF
--- a/blueprint-files/ember-cli-typescript/types/__app_name__/index.d.ts
+++ b/blueprint-files/ember-cli-typescript/types/__app_name__/index.d.ts
@@ -1,1 +1,1 @@
-<%= baseDeclarations(dasherizedPackageName) %>
+<%= indexDeclarations(dasherizedPackageName) %>

--- a/blueprint-files/ember-cli-typescript/types/global.d.ts
+++ b/blueprint-files/ember-cli-typescript/types/global.d.ts
@@ -1,0 +1,1 @@
+<%= globalDeclarations(dasherizedPackageName) %>

--- a/ts/blueprints/ember-cli-typescript/index.js
+++ b/ts/blueprints/ember-cli-typescript/index.js
@@ -27,7 +27,7 @@ function buildTemplateDeclarations(projectName, layout) {
     case 'classic': return `${comment}
 declare module '${projectName}/templates/*' { ${moduleBody}}`;
     case 'pods': return `${comment}
-declare module '${projectName}/components/*/template' { ${moduleBody}}`;
+declare module '${projectName}/*/template' { ${moduleBody}}`;
     case 'mu': return `${comment}
 declare module '${projectName}/ui/components/*/template' { ${moduleBody}}`;
     default: throw new Error(`Unexpecte project layout type: "${layout}"`);

--- a/ts/tests/blueprints/ember-cli-typescript-test.ts
+++ b/ts/tests/blueprints/ember-cli-typescript-test.ts
@@ -134,6 +134,16 @@ describe('Acceptance: ember-cli-typescript generator', function() {
         expect(projectTypes).to.exist;
         expect(projectTypes).not.to.include(ects.APP_DECLARATIONS);
 
+        const globalTypes = file('types/global.d.ts');
+        expect(globalTypes).to.exist;
+        expect(globalTypes)
+          .to.include("declare module 'my-addon/templates/*'")
+          .to.include(`
+  import { TemplateFactory } from 'htmlbars-inline-precompile';
+  const tmpl: TemplateFactory;
+  export default tmpl;
+`);
+
         const environmentTypes = file('tests/dummy/app/config/environment.d.ts');
         expect(environmentTypes).to.exist;
 
@@ -194,6 +204,15 @@ describe('Acceptance: ember-cli-typescript generator', function() {
           expect(projectTypes).to.exist;
           expect(projectTypes).to.include(ects.APP_DECLARATIONS);
 
+          const globalTypes = file('types/global.d.ts');
+          expect(globalTypes).to.exist;
+          expect(globalTypes)
+            .to.include("declare module 'my-app/ui/components/*/template'")
+            .to.include(`  import { TemplateFactory } from 'htmlbars-inline-precompile';
+  const tmpl: TemplateFactory;
+  export default tmpl;
+`);
+
           const environmentTypes = file('config/environment.d.ts');
           expect(environmentTypes).to.exist;
 
@@ -240,6 +259,15 @@ describe('Acceptance: ember-cli-typescript generator', function() {
           const projectTypes = file('types/dummy/index.d.ts');
           expect(projectTypes).to.exist;
           expect(projectTypes).not.to.include(ects.APP_DECLARATIONS);
+
+          const globalTypes = file('types/global.d.ts');
+          expect(globalTypes).to.exist;
+          expect(globalTypes)
+            .to.include("declare module 'my-addon/ui/components/*/template'")
+            .to.include(`  import { TemplateFactory } from 'htmlbars-inline-precompile';
+  const tmpl: TemplateFactory;
+  export default tmpl;
+`);
 
           const environmentTypes = file('tests/dummy/config/environment.d.ts');
           expect(environmentTypes).to.exist;


### PR DESCRIPTION
Deliberately based off of #644, which is based off of #647
Fixes #242 
Related #192

This PR results in a `types/global.d.ts` file being generated, producing a module type augmentation for paths we expect to contain templates

```ts
  import { TemplateFactory } from 'htmlbars-inline-precompile';
  const tmpl: TemplateFactory;
  export default tmpl;
```

Depending on project layout the path of the module will be different

*Classic*
```ts
declare module 'foo/templates/*' { ... }
```
*Pods*
```ts
declare module 'foo/components/*/template' { ... }
```
*Module Unification*
```ts
declare module 'foo/ui/components/*/template' { ... }
```