### PR TITLE
Drop support for node 6 (EOL)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -70,7 +70,6 @@ module.exports = {
       },
       rules: {
         'node/no-unpublished-require': 'off',
-        'node/no-unsupported-features/es-syntax': 'off',
       },
     },
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,5 +15,6 @@
     "ember-beta": true,
     "ember-canary": true,
     "ember-default": true
-  }
+  },
+  "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "@typed-ember/renovate-config": "1.2.1",
     "@types/chai": "4.1.7",
     "@types/chai-as-promised": "7.1.0",
-    "@types/co": "4.6.1",
     "@types/console-ui": "2.2.0",
     "@types/core-object": "3.0.1",
     "@types/debug": "4.1.4",
@@ -134,7 +133,7 @@
     "hawk": "7"
   },
   "engines": {
-    "node": "6.* || 8.* || >= 10.*"
+    "node": "8.* || >= 10.*"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",

--- a/ts/tests/acceptance/build-test.ts
+++ b/ts/tests/acceptance/build-test.ts
@@ -1,4 +1,3 @@
-import co from 'co';
 import SkeletonApp from '../helpers/skeleton-app';
 import chai from 'ember-cli-blueprint-test-helpers/chai';
 import * as esprima from 'esprima';
@@ -25,90 +24,78 @@ describe('Acceptance: build', function() {
     app.teardown();
   });
 
-  it(
-    'builds and rebuilds files',
-    co.wrap(function*() {
-      app.writeFile(
-        'app/app.ts',
-        `
+  it('builds and rebuilds files', async () => {
+    app.writeFile(
+      'app/app.ts',
+      `
       export function add(a: number, b: number) {
         return a + b;
       }
     `
-      );
+    );
 
-      let server = app.serve();
+    let server = app.serve();
 
-      yield server.waitForBuild();
+    await server.waitForBuild();
 
-      expectModuleBody(
-        app,
-        'skeleton-app/app',
-        `
+    expectModuleBody(
+      app,
+      'skeleton-app/app',
+      `
       _exports.add = add;
       function add(a, b) {
         return a + b;
       }
     `
-      );
+    );
 
-      app.writeFile(
-        'app/app.ts',
-        `
+    app.writeFile(
+      'app/app.ts',
+      `
       export const foo: string = 'hello';
     `
-      );
+    );
 
-      yield server.waitForBuild();
+    await server.waitForBuild();
 
-      expectModuleBody(
-        app,
-        'skeleton-app/app',
-        `
+    expectModuleBody(
+      app,
+      'skeleton-app/app',
+      `
       _exports.foo = void 0;
       var foo = 'hello';
       _exports.foo = foo;
     `
-      );
-    })
-  );
+    );
+  });
 
-  it(
-    'fails the build when noEmitOnError is set and an error is emitted',
-    co.wrap(function*() {
-      app.writeFile('app/app.ts', `import { foo } from 'nonexistent';`);
+  it('fails the build when noEmitOnError is set and an error is emitted', async () => {
+    app.writeFile('app/app.ts', `import { foo } from 'nonexistent';`);
 
-      yield expect(app.build()).to.be.rejectedWith(`Cannot find module 'nonexistent'`);
-    })
-  );
+    await expect(app.build()).to.be.rejectedWith(`Cannot find module 'nonexistent'`);
+  });
 
-  it(
-    'serves a type error page when the build has failed',
-    co.wrap(function*() {
-      app.writeFile('app/index.html', 'plain index');
-      app.writeFile('app/app.ts', `import { foo } from 'nonexistent';`);
+  it('serves a type error page when the build has failed', async () => {
+    app.writeFile('app/index.html', 'plain index');
+    app.writeFile('app/app.ts', `import { foo } from 'nonexistent';`);
 
-      let server = app.serve();
-      let output = yield server.waitForOutput('Typechecking failed');
-      let response = yield server.request('/');
+    let server = app.serve();
+    let output = await server.waitForOutput('Typechecking failed');
+    let response = await server.request('/');
 
-      expect(output).to.include(`Cannot find module 'nonexistent'`);
-      expect(response.body).to.include(`Cannot find module 'nonexistent'`);
-    })
-  );
+    expect(output).to.include(`Cannot find module 'nonexistent'`);
+    expect(response.body).to.include(`Cannot find module 'nonexistent'`);
+  });
 
-  it(
-    "doesn't block builds for file changes that don't result in a typecheck",
-    co.wrap(function*() {
-      let server = app.serve();
+  it("doesn't block builds for file changes that don't result in a typecheck", async () => {
+    let server = app.serve();
 
-      yield server.waitForBuild();
+    await server.waitForBuild();
 
-      app.writeFile('app/some-template.hbs', '');
+    app.writeFile('app/some-template.hbs', '');
 
-      yield server.waitForBuild();
-    })
-  );
+    await server.waitForBuild();
+  });
 });
 
 function isExpressionStatement(stmt: Statement | ModuleDeclaration): stmt is ExpressionStatement {

--- a/ts/tests/blueprints/ember-cli-typescript-test.ts
+++ b/ts/tests/blueprints/ember-cli-typescript-test.ts
@@ -43,120 +43,112 @@ describe('Acceptance: ember-cli-typescript generator', function() {
     Blueprint.prototype.taskFor = originalTaskForFn;
   });
 
-  it('basic app', function() {
+  it('basic app', async () => {
     const args = ['ember-cli-typescript'];
 
-    return helpers
-      .emberNew()
-      .then(() => helpers.emberGenerate(args))
-      .then(() => {
-        const pkg = file('package.json');
-        expect(pkg).to.exist;
+    await helpers.emberNew();
+    await helpers.emberGenerate(args);
 
-        const pkgJson = JSON.parse(pkg.content);
-        expect(pkgJson.scripts.prepublishOnly).to.be.undefined;
-        expect(pkgJson.scripts.postpublish).to.be.undefined;
-        expect(pkgJson.devDependencies).to.include.all.keys('ember-cli-typescript-blueprints');
-        expect(pkgJson.devDependencies).to.include.all.keys('ember-data');
-        expect(pkgJson.devDependencies).to.include.all.keys('@types/ember-data');
-        expect(pkgJson.devDependencies).to.include.all.keys('ember-qunit');
-        expect(pkgJson.devDependencies).to.include.all.keys('@types/ember-qunit', '@types/qunit');
-        expect(pkgJson.devDependencies).to.not.have.any.keys('@types/ember-mocha', '@types/mocha');
+    const pkg = file('package.json');
+    expect(pkg).to.exist;
 
-        const tsconfig = file('tsconfig.json');
-        expect(tsconfig).to.exist;
+    const pkgJson = JSON.parse(pkg.content);
+    expect(pkgJson.scripts.prepublishOnly).to.be.undefined;
+    expect(pkgJson.scripts.postpublish).to.be.undefined;
+    expect(pkgJson.devDependencies).to.include.all.keys('ember-cli-typescript-blueprints');
+    expect(pkgJson.devDependencies).to.include.all.keys('ember-data');
+    expect(pkgJson.devDependencies).to.include.all.keys('@types/ember-data');
+    expect(pkgJson.devDependencies).to.include.all.keys('ember-qunit');
+    expect(pkgJson.devDependencies).to.include.all.keys('@types/ember-qunit', '@types/qunit');
+    expect(pkgJson.devDependencies).to.not.have.any.keys('@types/ember-mocha', '@types/mocha');
 
-        const tsconfigJson = JSON.parse(tsconfig.content);
-        expect(tsconfigJson.compilerOptions.paths).to.deep.equal({
-          'my-app/tests/*': ['tests/*'],
-          'my-app/*': ['app/*'],
-          '*': ['types/*'],
-        });
+    const tsconfig = file('tsconfig.json');
+    expect(tsconfig).to.exist;
 
-        expect(tsconfigJson.compilerOptions.inlineSourceMap).to.equal(true);
-        expect(tsconfigJson.compilerOptions.inlineSources).to.equal(true);
+    const tsconfigJson = JSON.parse(tsconfig.content);
+    expect(tsconfigJson.compilerOptions.paths).to.deep.equal({
+      'my-app/tests/*': ['tests/*'],
+      'my-app/*': ['app/*'],
+      '*': ['types/*'],
+    });
 
-        expect(tsconfigJson.include).to.deep.equal(['app/**/*', 'tests/**/*', 'types/**/*']);
+    expect(tsconfigJson.compilerOptions.inlineSourceMap).to.equal(true);
+    expect(tsconfigJson.compilerOptions.inlineSources).to.equal(true);
 
-        const projectTypes = file('types/my-app/index.d.ts');
-        expect(projectTypes).to.exist;
-        expect(projectTypes).to.include(ects.APP_DECLARATIONS);
+    expect(tsconfigJson.include).to.deep.equal(['app/**/*', 'tests/**/*', 'types/**/*']);
 
-        const environmentTypes = file('app/config/environment.d.ts');
-        expect(environmentTypes).to.exist;
+    const projectTypes = file('types/my-app/index.d.ts');
+    expect(projectTypes).to.exist;
+    expect(projectTypes).to.include(ects.APP_DECLARATIONS);
 
-        const emberDataCatchallTypes = file('types/ember-data/types/registries/model.d.ts');
-        expect(emberDataCatchallTypes).to.exist;
-      });
+    const environmentTypes = file('app/config/environment.d.ts');
+    expect(environmentTypes).to.exist;
+
+    const emberDataCatchallTypes = file('types/ember-data/types/registries/model.d.ts');
+    expect(emberDataCatchallTypes).to.exist;
   });
 
-  it('basic addon', function() {
+  it('basic addon', async () => {
     const args = ['ember-cli-typescript'];
 
-    return helpers
-      .emberNew({ target: 'addon' })
-      .then(() => helpers.emberGenerate(args))
-      .then(() => {
-        const pkg = file('package.json');
-        expect(pkg).to.exist;
+    await helpers.emberNew({ target: 'addon' });
+    await helpers.emberGenerate(args);
 
-        const pkgJson = JSON.parse(pkg.content);
-        expect(pkgJson.scripts.prepublishOnly).to.equal('ember ts:precompile');
-        expect(pkgJson.scripts.postpublish).to.equal('ember ts:clean');
-        expect(pkgJson.devDependencies).to.not.have.any.keys('ember-data');
-        expect(pkgJson.devDependencies).to.not.have.any.keys('@types/ember-data');
-        expect(pkgJson.devDependencies).to.include.all.keys('ember-qunit');
-        expect(pkgJson.devDependencies).to.include.all.keys('@types/ember-qunit', '@types/qunit');
-        expect(pkgJson.devDependencies).to.not.have.any.keys('@types/ember-mocha', '@types/mocha');
+    const pkg = file('package.json');
+    expect(pkg).to.exist;
 
-        const tsconfig = file('tsconfig.json');
-        expect(tsconfig).to.exist;
+    const pkgJson = JSON.parse(pkg.content);
+    expect(pkgJson.scripts.prepublishOnly).to.equal('ember ts:precompile');
+    expect(pkgJson.scripts.postpublish).to.equal('ember ts:clean');
+    expect(pkgJson.devDependencies).to.not.have.any.keys('ember-data');
+    expect(pkgJson.devDependencies).to.not.have.any.keys('@types/ember-data');
+    expect(pkgJson.devDependencies).to.include.all.keys('ember-qunit');
+    expect(pkgJson.devDependencies).to.include.all.keys('@types/ember-qunit', '@types/qunit');
+    expect(pkgJson.devDependencies).to.not.have.any.keys('@types/ember-mocha', '@types/mocha');
 
-        const tsconfigJson = JSON.parse(tsconfig.content);
-        expect(tsconfigJson.compilerOptions.paths).to.deep.equal({
-          'dummy/tests/*': ['tests/*'],
-          'dummy/*': ['tests/dummy/app/*', 'app/*'],
-          'my-addon': ['addon'],
-          'my-addon/*': ['addon/*'],
-          'my-addon/test-support': ['addon-test-support'],
-          'my-addon/test-support/*': ['addon-test-support/*'],
-          '*': ['types/*'],
-        });
+    const tsconfig = file('tsconfig.json');
+    expect(tsconfig).to.exist;
 
-        expect(tsconfigJson.include).to.deep.equal([
-          'app/**/*',
-          'addon/**/*',
-          'tests/**/*',
-          'types/**/*',
-          'test-support/**/*',
-          'addon-test-support/**/*',
-        ]);
+    const tsconfigJson = JSON.parse(tsconfig.content);
+    expect(tsconfigJson.compilerOptions.paths).to.deep.equal({
+      'dummy/tests/*': ['tests/*'],
+      'dummy/*': ['tests/dummy/app/*', 'app/*'],
+      'my-addon': ['addon'],
+      'my-addon/*': ['addon/*'],
+      'my-addon/test-support': ['addon-test-support'],
+      'my-addon/test-support/*': ['addon-test-support/*'],
+      '*': ['types/*'],
+    });
 
-        const projectTypes = file('types/dummy/index.d.ts');
-        expect(projectTypes).to.exist;
-        expect(projectTypes).not.to.include(ects.APP_DECLARATIONS);
+    expect(tsconfigJson.include).to.deep.equal([
+      'app/**/*',
+      'addon/**/*',
+      'tests/**/*',
+      'types/**/*',
+      'test-support/**/*',
+      'addon-test-support/**/*',
+    ]);
 
-        const globalTypes = file('types/global.d.ts');
-        expect(globalTypes).to.exist;
-        expect(globalTypes)
-          .to.include("declare module 'my-addon/templates/*'")
-          .to.include(
-            `
+    const projectTypes = file('types/dummy/index.d.ts');
+    expect(projectTypes).to.exist;
+    expect(projectTypes).not.to.include(ects.APP_DECLARATIONS);
+
+    const globalTypes = file('types/global.d.ts');
+    expect(globalTypes).to.exist;
+    expect(globalTypes).to.include("declare module 'my-addon/templates/*'").to.include(`
   import { TemplateFactory } from 'htmlbars-inline-precompile';
   const tmpl: TemplateFactory;
   export default tmpl;
-`
-          );
+`);
 
-        const environmentTypes = file('tests/dummy/app/config/environment.d.ts');
-        expect(environmentTypes).to.exist;
+    const environmentTypes = file('tests/dummy/app/config/environment.d.ts');
+    expect(environmentTypes).to.exist;
 
-        const emberDataCatchallTypes = file('types/ember-data/types/registries/model.d.ts');
-        expect(emberDataCatchallTypes).not.to.exist;
-      });
+    const emberDataCatchallTypes = file('types/ember-data/types/registries/model.d.ts');
+    expect(emberDataCatchallTypes).not.to.exist;
   });
 
-  describe('module unification', function() {
+  describe('module unification', () => {
     const originalIsMU = Project.prototype.isModuleUnification;
 
     beforeEach(function() {
@@ -167,341 +159,297 @@ describe('Acceptance: ember-cli-typescript generator', function() {
       Project.prototype.isModuleUnification = originalIsMU;
     });
 
-    it('basic app', function() {
+    it('basic app', async () => {
       const args = ['ember-cli-typescript'];
 
-      return helpers
-        .emberNew()
-        .then(() => helpers.emberGenerate(args))
-        .then(() => {
-          const pkg = file('package.json');
-          expect(pkg).to.exist;
+      await helpers.emberNew();
+      await helpers.emberGenerate(args);
 
-          const pkgJson = JSON.parse(pkg.content);
-          expect(pkgJson.scripts.prepublishOnly).to.be.undefined;
-          expect(pkgJson.scripts.postpublish).to.be.undefined;
-          expect(pkgJson.devDependencies).to.include.all.keys('ember-data');
-          expect(pkgJson.devDependencies).to.include.all.keys('@types/ember-data');
-          expect(pkgJson.devDependencies).to.include.all.keys('ember-qunit');
-          expect(pkgJson.devDependencies).to.include.all.keys('@types/ember-qunit', '@types/qunit');
-          expect(pkgJson.devDependencies).to.not.have.any.keys(
-            '@types/ember-mocha',
-            '@types/mocha'
-          );
+      const pkg = file('package.json');
+      expect(pkg).to.exist;
 
-          const tsconfig = file('tsconfig.json');
-          expect(tsconfig).to.exist;
+      const pkgJson = JSON.parse(pkg.content);
+      expect(pkgJson.scripts.prepublishOnly).to.be.undefined;
+      expect(pkgJson.scripts.postpublish).to.be.undefined;
+      expect(pkgJson.devDependencies).to.include.all.keys('ember-data');
+      expect(pkgJson.devDependencies).to.include.all.keys('@types/ember-data');
+      expect(pkgJson.devDependencies).to.include.all.keys('ember-qunit');
+      expect(pkgJson.devDependencies).to.include.all.keys('@types/ember-qunit', '@types/qunit');
+      expect(pkgJson.devDependencies).to.not.have.any.keys('@types/ember-mocha', '@types/mocha');
 
-          const tsconfigJson = JSON.parse(tsconfig.content);
-          expect(tsconfigJson.compilerOptions.paths).to.deep.equal({
-            'my-app/tests/*': ['tests/*'],
-            'my-app/src/*': ['src/*'],
-            '*': ['types/*'],
-          });
+      const tsconfig = file('tsconfig.json');
+      expect(tsconfig).to.exist;
 
-          expect(tsconfigJson.compilerOptions.inlineSourceMap).to.equal(true);
-          expect(tsconfigJson.compilerOptions.inlineSources).to.equal(true);
+      const tsconfigJson = JSON.parse(tsconfig.content);
+      expect(tsconfigJson.compilerOptions.paths).to.deep.equal({
+        'my-app/tests/*': ['tests/*'],
+        'my-app/src/*': ['src/*'],
+        '*': ['types/*'],
+      });
 
-          expect(tsconfigJson.include).to.deep.equal(['src/**/*', 'tests/**/*', 'types/**/*']);
+      expect(tsconfigJson.compilerOptions.inlineSourceMap).to.equal(true);
+      expect(tsconfigJson.compilerOptions.inlineSources).to.equal(true);
 
-          const projectTypes = file('types/my-app/index.d.ts');
-          expect(projectTypes).to.exist;
-          expect(projectTypes).to.include(ects.APP_DECLARATIONS);
+      expect(tsconfigJson.include).to.deep.equal(['src/**/*', 'tests/**/*', 'types/**/*']);
 
-          const globalTypes = file('types/global.d.ts');
-          expect(globalTypes).to.exist;
-          expect(globalTypes)
-            .to.include("declare module 'my-app/ui/components/*/template'")
-            .to.include(
-              `  import { TemplateFactory } from 'htmlbars-inline-precompile';
+      const projectTypes = file('types/my-app/index.d.ts');
+      expect(projectTypes).to.exist;
+      expect(projectTypes).to.include(ects.APP_DECLARATIONS);
+
+      const globalTypes = file('types/global.d.ts');
+      expect(globalTypes).to.exist;
+      expect(globalTypes).to.include("declare module 'my-app/ui/components/*/template'").to
+        .include(`  import { TemplateFactory } from 'htmlbars-inline-precompile';
   const tmpl: TemplateFactory;
   export default tmpl;
-`
-            );
+`);
 
-          const environmentTypes = file('config/environment.d.ts');
-          expect(environmentTypes).to.exist;
+      const environmentTypes = file('config/environment.d.ts');
+      expect(environmentTypes).to.exist;
 
-          const emberDataCatchallTypes = file('types/ember-data/types/registries/model.d.ts');
-          expect(emberDataCatchallTypes).to.exist;
-        });
+      const emberDataCatchallTypes = file('types/ember-data/types/registries/model.d.ts');
+      expect(emberDataCatchallTypes).to.exist;
     });
 
-    it('basic addon', function() {
+    it('basic addon', async () => {
       const args = ['ember-cli-typescript'];
 
-      return helpers
-        .emberNew({ target: 'addon' })
-        .then(() => helpers.emberGenerate(args))
-        .then(() => {
-          const pkg = file('package.json');
-          expect(pkg).to.exist;
+      await helpers.emberNew({ target: 'addon' });
+      await helpers.emberGenerate(args);
+      const pkg = file('package.json');
+      expect(pkg).to.exist;
 
-          const pkgJson = JSON.parse(pkg.content);
-          expect(pkgJson.scripts.prepublishOnly).to.equal('ember ts:precompile');
-          expect(pkgJson.scripts.postpublish).to.equal('ember ts:clean');
-          expect(pkgJson.devDependencies).to.not.have.any.keys('ember-data');
-          expect(pkgJson.devDependencies).to.not.have.any.keys('@types/ember-data');
-          expect(pkgJson.devDependencies).to.include.all.keys('ember-qunit');
-          expect(pkgJson.devDependencies).to.include.all.keys('@types/ember-qunit', '@types/qunit');
-          expect(pkgJson.devDependencies).to.not.have.any.keys(
-            '@types/ember-mocha',
-            '@types/mocha'
-          );
+      const pkgJson = JSON.parse(pkg.content);
+      expect(pkgJson.scripts.prepublishOnly).to.equal('ember ts:precompile');
+      expect(pkgJson.scripts.postpublish).to.equal('ember ts:clean');
+      expect(pkgJson.devDependencies).to.not.have.any.keys('ember-data');
+      expect(pkgJson.devDependencies).to.not.have.any.keys('@types/ember-data');
+      expect(pkgJson.devDependencies).to.include.all.keys('ember-qunit');
+      expect(pkgJson.devDependencies).to.include.all.keys('@types/ember-qunit', '@types/qunit');
+      expect(pkgJson.devDependencies).to.not.have.any.keys('@types/ember-mocha', '@types/mocha');
 
-          const tsconfig = file('tsconfig.json');
-          expect(tsconfig).to.exist;
+      const tsconfig = file('tsconfig.json');
+      expect(tsconfig).to.exist;
 
-          const tsconfigJson = JSON.parse(tsconfig.content);
-          expect(tsconfigJson.compilerOptions.paths).to.deep.equal({
-            'dummy/tests/*': ['tests/*'],
-            'dummy/src/*': ['tests/dummy/src/*'],
-            'my-addon/src/*': ['src/*'],
-            '*': ['types/*'],
-          });
+      const tsconfigJson = JSON.parse(tsconfig.content);
+      expect(tsconfigJson.compilerOptions.paths).to.deep.equal({
+        'dummy/tests/*': ['tests/*'],
+        'dummy/src/*': ['tests/dummy/src/*'],
+        'my-addon/src/*': ['src/*'],
+        '*': ['types/*'],
+      });
 
-          expect(tsconfigJson.include).to.deep.equal(['src/**/*', 'tests/**/*', 'types/**/*']);
+      expect(tsconfigJson.include).to.deep.equal(['src/**/*', 'tests/**/*', 'types/**/*']);
 
-          const projectTypes = file('types/dummy/index.d.ts');
-          expect(projectTypes).to.exist;
-          expect(projectTypes).not.to.include(ects.APP_DECLARATIONS);
+      const projectTypes = file('types/dummy/index.d.ts');
+      expect(projectTypes).to.exist;
+      expect(projectTypes).not.to.include(ects.APP_DECLARATIONS);
 
-          const globalTypes = file('types/global.d.ts');
-          expect(globalTypes).to.exist;
-          expect(globalTypes)
-            .to.include("declare module 'my-addon/ui/components/*/template'")
-            .to.include(
-              `  import { TemplateFactory } from 'htmlbars-inline-precompile';
+      const globalTypes = file('types/global.d.ts');
+      expect(globalTypes).to.exist;
+      expect(globalTypes).to.include("declare module 'my-addon/ui/components/*/template'").to
+        .include(`  import { TemplateFactory } from 'htmlbars-inline-precompile';
   const tmpl: TemplateFactory;
   export default tmpl;
-`
-            );
+`);
 
-          const environmentTypes = file('tests/dummy/config/environment.d.ts');
-          expect(environmentTypes).to.exist;
+      const environmentTypes = file('tests/dummy/config/environment.d.ts');
+      expect(environmentTypes).to.exist;
 
-          const emberDataCatchallTypes = file('types/ember-data/types/registries/model.d.ts');
-          expect(emberDataCatchallTypes).not.to.exist;
-        });
+      const emberDataCatchallTypes = file('types/ember-data/types/registries/model.d.ts');
+      expect(emberDataCatchallTypes).not.to.exist;
     });
   });
 
-  it('in-repo addons', function() {
+  it('in-repo addons', async () => {
     const args = ['ember-cli-typescript'];
 
-    return helpers
-      .emberNew()
-      .then(() => {
-        const packagePath = path.resolve(process.cwd(), 'package.json');
-        const contents = JSON.parse(fs.readFileSync(packagePath, { encoding: 'utf8' }));
-        contents['ember-addon'] = {
-          paths: ['lib/my-addon-1', 'lib/my-addon-2'],
-        };
-        fs.writeFileSync(packagePath, JSON.stringify(contents, null, 2));
-      })
-      .then(() => helpers.emberGenerate(args))
-      .then(() => {
-        const tsconfig = file('tsconfig.json');
-        expect(tsconfig).to.exist;
+    await helpers.emberNew();
 
-        const json = JSON.parse(tsconfig.content);
-        expect(json.compilerOptions.paths).to.deep.equal({
-          'my-app/tests/*': ['tests/*'],
-          'my-app/*': ['app/*', 'lib/my-addon-1/app/*', 'lib/my-addon-2/app/*'],
-          'my-addon-1': ['lib/my-addon-1/addon'],
-          'my-addon-1/*': ['lib/my-addon-1/addon/*'],
-          'my-addon-1/test-support': ['lib/my-addon-1/addon-test-support'],
-          'my-addon-1/test-support/*': ['lib/my-addon-1/addon-test-support/*'],
-          'my-addon-2': ['lib/my-addon-2/addon'],
-          'my-addon-2/*': ['lib/my-addon-2/addon/*'],
-          'my-addon-2/test-support': ['lib/my-addon-2/addon-test-support'],
-          'my-addon-2/test-support/*': ['lib/my-addon-2/addon-test-support/*'],
-          '*': ['types/*'],
-        });
+    const packagePath = path.resolve(process.cwd(), 'package.json');
+    const contents = JSON.parse(fs.readFileSync(packagePath, { encoding: 'utf8' }));
+    contents['ember-addon'] = {
+      paths: ['lib/my-addon-1', 'lib/my-addon-2'],
+    };
+    fs.writeFileSync(packagePath, JSON.stringify(contents, null, 2));
 
-        expect(json.include).to.deep.equal([
-          'app/**/*',
-          'tests/**/*',
-          'types/**/*',
-          'lib/my-addon-1/**/*',
-          'lib/my-addon-2/**/*',
-        ]);
+    await helpers.emberGenerate(args);
 
-        const projectTypes = file('types/my-app/index.d.ts');
-        expect(projectTypes).to.exist;
-        expect(projectTypes).to.include(ects.APP_DECLARATIONS);
+    const tsconfig = file('tsconfig.json');
+    expect(tsconfig).to.exist;
 
-        const emberDataCatchallTypes = file('types/ember-data/types/registries/model.d.ts');
-        expect(emberDataCatchallTypes).to.exist;
-      });
+    const json = JSON.parse(tsconfig.content);
+    expect(json.compilerOptions.paths).to.deep.equal({
+      'my-app/tests/*': ['tests/*'],
+      'my-app/*': ['app/*', 'lib/my-addon-1/app/*', 'lib/my-addon-2/app/*'],
+      'my-addon-1': ['lib/my-addon-1/addon'],
+      'my-addon-1/*': ['lib/my-addon-1/addon/*'],
+      'my-addon-1/test-support': ['lib/my-addon-1/addon-test-support'],
+      'my-addon-1/test-support/*': ['lib/my-addon-1/addon-test-support/*'],
+      'my-addon-2': ['lib/my-addon-2/addon'],
+      'my-addon-2/*': ['lib/my-addon-2/addon/*'],
+      'my-addon-2/test-support': ['lib/my-addon-2/addon-test-support'],
+      'my-addon-2/test-support/*': ['lib/my-addon-2/addon-test-support/*'],
+      '*': ['types/*'],
+    });
+
+    expect(json.include).to.deep.equal([
+      'app/**/*',
+      'tests/**/*',
+      'types/**/*',
+      'lib/my-addon-1/**/*',
+      'lib/my-addon-2/**/*',
+    ]);
+
+    const projectTypes = file('types/my-app/index.d.ts');
+    expect(projectTypes).to.exist;
+    expect(projectTypes).to.include(ects.APP_DECLARATIONS);
+
+    const emberDataCatchallTypes = file('types/ember-data/types/registries/model.d.ts');
+    expect(emberDataCatchallTypes).to.exist;
   });
 
-  it('app with Mirage', function() {
+  it('app with Mirage', async () => {
     const args = ['ember-cli-typescript'];
 
-    return helpers
-      .emberNew()
-      .then(() => {
-        const packagePath = path.resolve(process.cwd(), 'package.json');
-        const contents = JSON.parse(fs.readFileSync(packagePath, { encoding: 'utf8' }));
-        contents.devDependencies['ember-cli-mirage'] = '*';
-        fs.writeFileSync(packagePath, JSON.stringify(contents, null, 2));
-      })
-      .then(() => helpers.emberGenerate(args))
-      .then(() => {
-        const tsconfig = file('tsconfig.json');
-        expect(tsconfig).to.exist;
+    await helpers.emberNew();
 
-        const json = JSON.parse(tsconfig.content);
-        expect(json.compilerOptions.paths).to.deep.equal({
-          'my-app/tests/*': ['tests/*'],
-          'my-app/mirage/*': ['mirage/*'],
-          'my-app/*': ['app/*'],
-          '*': ['types/*'],
-        });
+    const packagePath = path.resolve(process.cwd(), 'package.json');
+    const contents = JSON.parse(fs.readFileSync(packagePath, { encoding: 'utf8' }));
+    contents.devDependencies['ember-cli-mirage'] = '*';
+    fs.writeFileSync(packagePath, JSON.stringify(contents, null, 2));
 
-        expect(json.include).to.deep.equal(['app/**/*', 'tests/**/*', 'types/**/*', 'mirage/**/*']);
-      });
+    await helpers.emberGenerate(args);
+
+    const tsconfig = file('tsconfig.json');
+    expect(tsconfig).to.exist;
+
+    const json = JSON.parse(tsconfig.content);
+    expect(json.compilerOptions.paths).to.deep.equal({
+      'my-app/tests/*': ['tests/*'],
+      'my-app/mirage/*': ['mirage/*'],
+      'my-app/*': ['app/*'],
+      '*': ['types/*'],
+    });
+
+    expect(json.include).to.deep.equal(['app/**/*', 'tests/**/*', 'types/**/*', 'mirage/**/*']);
   });
 
-  it('addon with Mirage', function() {
+  it('addon with Mirage', async () => {
     const args = ['ember-cli-typescript'];
 
-    return helpers
-      .emberNew({ target: 'addon' })
-      .then(() => {
-        const packagePath = path.resolve(process.cwd(), 'package.json');
-        const contents = JSON.parse(fs.readFileSync(packagePath, { encoding: 'utf8' }));
-        contents.devDependencies['ember-cli-mirage'] = '*';
-        fs.writeFileSync(packagePath, JSON.stringify(contents, null, 2));
-      })
-      .then(() => helpers.emberGenerate(args))
-      .then(() => {
-        const tsconfig = file('tsconfig.json');
-        expect(tsconfig).to.exist;
+    await helpers.emberNew({ target: 'addon' });
 
-        const json = JSON.parse(tsconfig.content);
-        expect(json.compilerOptions.paths).to.deep.equal({
-          'dummy/tests/*': ['tests/*'],
-          'dummy/mirage/*': ['tests/dummy/mirage/*'],
-          'dummy/*': ['tests/dummy/app/*', 'app/*'],
-          'my-addon': ['addon'],
-          'my-addon/*': ['addon/*'],
-          'my-addon/test-support': ['addon-test-support'],
-          'my-addon/test-support/*': ['addon-test-support/*'],
-          '*': ['types/*'],
-        });
+    const packagePath = path.resolve(process.cwd(), 'package.json');
+    const contents = JSON.parse(fs.readFileSync(packagePath, { encoding: 'utf8' }));
+    contents.devDependencies['ember-cli-mirage'] = '*';
+    fs.writeFileSync(packagePath, JSON.stringify(contents, null, 2));
 
-        expect(json.include).to.deep.equal([
-          'app/**/*',
-          'addon/**/*',
-          'tests/**/*',
-          'types/**/*',
-          'test-support/**/*',
-          'addon-test-support/**/*',
-        ]);
-      });
+    await helpers.emberGenerate(args);
+
+    const tsconfig = file('tsconfig.json');
+    expect(tsconfig).to.exist;
+
+    const json = JSON.parse(tsconfig.content);
+    expect(json.compilerOptions.paths).to.deep.equal({
+      'dummy/tests/*': ['tests/*'],
+      'dummy/mirage/*': ['tests/dummy/mirage/*'],
+      'dummy/*': ['tests/dummy/app/*', 'app/*'],
+      'my-addon': ['addon'],
+      'my-addon/*': ['addon/*'],
+      'my-addon/test-support': ['addon-test-support'],
+      'my-addon/test-support/*': ['addon-test-support/*'],
+      '*': ['types/*'],
+    });
+
+    expect(json.include).to.deep.equal([
+      'app/**/*',
+      'addon/**/*',
+      'tests/**/*',
+      'types/**/*',
+      'test-support/**/*',
+      'addon-test-support/**/*',
+    ]);
   });
 
   describe('ember-mocha', function() {
-    it('app with ember-cli-mocha', function() {
+    it('app with ember-cli-mocha', async () => {
       const args = ['ember-cli-typescript'];
 
-      return helpers
-        .emberNew()
-        .then(() =>
-          helpers.modifyPackages([
-            { name: 'ember-cli-mocha', dev: true },
-            { name: 'ember-qunit', delete: true },
-          ])
-        )
-        .then(() => helpers.emberGenerate(args))
-        .then(() => {
-          const pkg = file('package.json');
-          expect(pkg).to.exist;
+      await helpers.emberNew();
 
-          const pkgJson = JSON.parse(pkg.content);
-          expect(pkgJson.devDependencies).to.include.all.keys('@types/ember-mocha', '@types/mocha');
-          expect(pkgJson.devDependencies).to.not.have.any.keys(
-            '@types/ember-qunit',
-            '@types/qunit'
-          );
-        });
+      helpers.modifyPackages([
+        { name: 'ember-cli-mocha', dev: true },
+        { name: 'ember-qunit', delete: true },
+      ]);
+
+      await helpers.emberGenerate(args);
+
+      const pkg = file('package.json');
+      expect(pkg).to.exist;
+
+      const pkgJson = JSON.parse(pkg.content);
+      expect(pkgJson.devDependencies).to.include.all.keys('@types/ember-mocha', '@types/mocha');
+      expect(pkgJson.devDependencies).to.not.have.any.keys('@types/ember-qunit', '@types/qunit');
     });
 
-    it('app with ember-mocha', function() {
+    it('app with ember-mocha', async () => {
       const args = ['ember-cli-typescript'];
 
-      return helpers
-        .emberNew()
-        .then(() =>
-          helpers.modifyPackages([
-            { name: 'ember-mocha', dev: true },
-            { name: 'ember-qunit', delete: true },
-          ])
-        )
-        .then(() => helpers.emberGenerate(args))
-        .then(() => {
-          const pkg = file('package.json');
-          expect(pkg).to.exist;
+      await helpers.emberNew();
 
-          const pkgJson = JSON.parse(pkg.content);
-          expect(pkgJson.devDependencies).to.include.all.keys('@types/ember-mocha', '@types/mocha');
-          expect(pkgJson.devDependencies).to.not.have.any.keys(
-            '@types/ember-qunit',
-            '@types/qunit'
-          );
-        });
+      helpers.modifyPackages([
+        { name: 'ember-mocha', dev: true },
+        { name: 'ember-qunit', delete: true },
+      ]);
+      await helpers.emberGenerate(args);
+
+      const pkg = file('package.json');
+      expect(pkg).to.exist;
+
+      const pkgJson = JSON.parse(pkg.content);
+      expect(pkgJson.devDependencies).to.include.all.keys('@types/ember-mocha', '@types/mocha');
+      expect(pkgJson.devDependencies).to.not.have.any.keys('@types/ember-qunit', '@types/qunit');
     });
 
-    it('addon with ember-cli-mocha', function() {
+    it('addon with ember-cli-mocha', async () => {
       const args = ['ember-cli-typescript'];
 
-      return helpers
-        .emberNew({ target: 'addon' })
-        .then(() =>
-          helpers.modifyPackages([
-            { name: 'ember-cli-mocha', dev: true },
-            { name: 'ember-qunit', delete: true },
-          ])
-        )
-        .then(() => helpers.emberGenerate(args))
-        .then(() => {
-          const pkg = file('package.json');
-          expect(pkg).to.exist;
+      await helpers.emberNew({ target: 'addon' });
 
-          const pkgJson = JSON.parse(pkg.content);
-          expect(pkgJson.devDependencies).to.include.all.keys('@types/ember-mocha', '@types/mocha');
-          expect(pkgJson.devDependencies).to.not.have.any.keys(
-            '@types/ember-qunit',
-            '@types/qunit'
-          );
-        });
+      helpers.modifyPackages([
+        { name: 'ember-cli-mocha', dev: true },
+        { name: 'ember-qunit', delete: true },
+      ]);
+
+      await helpers.emberGenerate(args);
+
+      const pkg = file('package.json');
+      expect(pkg).to.exist;
+
+      const pkgJson = JSON.parse(pkg.content);
+      expect(pkgJson.devDependencies).to.include.all.keys('@types/ember-mocha', '@types/mocha');
+      expect(pkgJson.devDependencies).to.not.have.any.keys('@types/ember-qunit', '@types/qunit');
     });
 
-    it('addon with ember-mocha', function() {
+    it('addon with ember-mocha', async () => {
       const args = ['ember-cli-typescript'];
 
-      return helpers
-        .emberNew({ target: 'addon' })
-        .then(() =>
-          helpers.modifyPackages([
-            { name: 'ember-mocha', dev: true },
-            { name: 'ember-qunit', delete: true },
-          ])
-        )
-        .then(() => helpers.emberGenerate(args))
-        .then(() => {
-          const pkg = file('package.json');
-          expect(pkg).to.exist;
+      await helpers.emberNew({ target: 'addon' });
 
-          const pkgJson = JSON.parse(pkg.content);
-          expect(pkgJson.devDependencies).to.include.all.keys('@types/ember-mocha', '@types/mocha');
-          expect(pkgJson.devDependencies).to.not.have.any.keys(
-            '@types/ember-qunit',
-            '@types/qunit'
-          );
-        });
+      helpers.modifyPackages([
+        { name: 'ember-mocha', dev: true },
+        { name: 'ember-qunit', delete: true },
+      ]);
+
+      await helpers.emberGenerate(args);
+
+      const pkg = file('package.json');
+      expect(pkg).to.exist;
+
+      const pkgJson = JSON.parse(pkg.content);
+      expect(pkgJson.devDependencies).to.include.all.keys('@types/ember-mocha', '@types/mocha');
+      expect(pkgJson.devDependencies).to.not.have.any.keys('@types/ember-qunit', '@types/qunit');
     });
   });
 });

--- a/ts/tests/commands/clean-test.ts
+++ b/ts/tests/commands/clean-test.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import * as fs from 'fs-extra';
 import walkSync from 'walk-sync';
 
@@ -14,11 +12,12 @@ const expect = chai.expect;
 describe('Acceptance: ts:clean command', function() {
   setupTestHooks(this);
 
-  beforeEach(function() {
-    return emberNew({ target: 'addon' }).then(() => ember(['generate', 'ember-cli-typescript']));
+  beforeEach(async () => {
+    await emberNew({ target: 'addon' });
+    await ember(['generate', 'ember-cli-typescript']);
   });
 
-  it('removes all generated files', function() {
+  it('removes all generated files', async () => {
     fs.ensureDirSync('dist');
     fs.ensureDirSync('app');
     fs.ensureDirSync('addon');
@@ -26,11 +25,10 @@ describe('Acceptance: ts:clean command', function() {
     fs.writeFileSync('addon/test-file.ts', `export const testString: string = 'addon';`);
 
     let before = walkSync(process.cwd());
-    return ember(['ts:precompile'])
-      .then(() => ember(['ts:clean']))
-      .then(() => {
-        let after = walkSync(process.cwd());
-        expect(after).to.deep.equal(before);
-      });
+    await ember(['ts:precompile']);
+    await ember(['ts:clean']);
+
+    let after = walkSync(process.cwd());
+    expect(after).to.deep.equal(before);
   });
 });

--- a/ts/tests/commands/precompile-test.ts
+++ b/ts/tests/commands/precompile-test.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import * as fs from 'fs-extra';
 
 import ember from 'ember-cli-blueprint-test-helpers/lib/helpers/ember';
@@ -14,33 +12,34 @@ const file = chai.file;
 describe('Acceptance: ts:precompile command', function() {
   setupTestHooks(this);
 
-  beforeEach(function() {
-    return emberNew({ target: 'addon' }).then(() => ember(['generate', 'ember-cli-typescript']));
+  beforeEach(async () => {
+    await emberNew({ target: 'addon' });
+    await ember(['generate', 'ember-cli-typescript']);
   });
 
-  it('generates .d.ts files from the addon tree', function() {
+  it('generates .d.ts files from the addon tree', async () => {
     fs.ensureDirSync('addon');
     fs.writeFileSync('addon/test-file.ts', `export const testString: string = 'hello';`);
 
-    return ember(['ts:precompile']).then(() => {
-      let declaration = file('test-file.d.ts');
-      expect(declaration).to.exist;
-      expect(declaration.content.trim()).to.equal(`export declare const testString: string;`);
-    });
+    await ember(['ts:precompile']);
+
+    let declaration = file('test-file.d.ts');
+    expect(declaration).to.exist;
+    expect(declaration.content.trim()).to.equal(`export declare const testString: string;`);
   });
 
-  it('generates nothing from the app tree', function() {
+  it('generates nothing from the app tree', async () => {
     fs.ensureDirSync('app');
     fs.writeFileSync('app/test-file.ts', `export const testString: string = 'hello';`);
 
-    return ember(['ts:precompile']).then(() => {
-      let declaration = file('test-file.d.ts');
-      expect(declaration).not.to.exist;
-    });
+    await ember(['ts:precompile']);
+
+    let declaration = file('test-file.d.ts');
+    expect(declaration).not.to.exist;
   });
 
   describe('module unification', function() {
-    it('generates .d.ts files from the src tree', function() {
+    it('generates .d.ts files from the src tree', async () => {
       fs.ensureDirSync('src');
       fs.writeFileSync('src/test-file.ts', `export const testString: string = 'hello';`);
 
@@ -50,16 +49,16 @@ describe('Acceptance: ts:precompile command', function() {
       tsconfig.compilerOptions.paths[`${pkg.name}/src/*`] = ['src/*'];
       fs.writeJSONSync('tsconfig.json', tsconfig);
 
-      return ember(['ts:precompile']).then(() => {
-        let declaration = file('src/test-file.d.ts');
-        expect(declaration).to.exist;
-        expect(declaration.content.trim()).to.equal(`export declare const testString: string;`);
-      });
+      await ember(['ts:precompile']);
+
+      let declaration = file('src/test-file.d.ts');
+      expect(declaration).to.exist;
+      expect(declaration.content.trim()).to.equal(`export declare const testString: string;`);
     });
   });
 
-  describe('addon-test-support', function() {
-    it('generates .d.ts files in remapped locations', function() {
+  describe('remapped addon-test-support', function() {
+    it('generates .d.ts files in the mapped location', async () => {
       fs.ensureDirSync('addon-test-support');
       fs.writeFileSync(
         'addon-test-support/test-file.ts',
@@ -72,11 +71,11 @@ describe('Acceptance: ts:precompile command', function() {
       tsconfig.compilerOptions.paths[`${pkg.name}/*`] = ['addon-test-support/*'];
       fs.writeJSONSync('tsconfig.json', tsconfig);
 
-      return ember(['ts:precompile']).then(() => {
-        let declaration = file('test-file.d.ts');
-        expect(declaration).to.exist;
-        expect(declaration.content.trim()).to.equal(`export declare const testString: string;`);
-      });
+      await ember(['ts:precompile']);
+
+      let declaration = file('test-file.d.ts');
+      expect(declaration).to.exist;
+      expect(declaration.content.trim()).to.equal(`export declare const testString: string;`);
     });
   });
 

--- a/ts/tsconfig.json
+++ b/ts/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2016",
+    "target": "es2017",
     "module": "commonjs",
     "moduleResolution": "node",
     "allowJs": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -981,11 +981,6 @@
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.1.7.tgz#1b8e33b61a8c09cbe1f85133071baa0dbf9fa71a"
   integrity sha512-2Y8uPt0/jwjhQ6EiluT0XCri1Dbplr0ZxfFXUz+ye13gaqE8u5gL5ppao1JrUYr9cIip5S6MvQzBS7Kke7U9VA==
 
-"@types/co@4.6.1":
-  version "4.6.1"
-  resolved "https://registry.yarnpkg.com/@types/co/-/co-4.6.1.tgz#37a1bac5735ae52bb61dbb20afbdce6e2068c521"
-  integrity sha512-2dpln7oTdS98LCgE5Y9VGtRPz3qjS3oTZigNazYAPLf90sl25HPvEZxBSH5yHByX9Jlnp4S4Y8MwkS73QUM1PA==
-
 "@types/connect@*":
   version "3.4.32"
   resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.32.tgz#aa0e9616b9435ccad02bc52b5b454ffc2c70ba28"
@@ -8484,10 +8479,12 @@ imurmurhash@^0.1.4:
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
 
 "in-repo-a@link:tests/dummy/lib/in-repo-a":
-  version "1.0.0"
+  version "0.0.0"
+  uid ""
 
 "in-repo-b@link:tests/dummy/lib/in-repo-b":
-  version "1.0.0"
+  version "0.0.0"
+  uid ""
 
 include-path-searcher@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
Deliberately based on a bunch of other PRs

* #647 
   * #644 
      * #643
         * this PR

Node.js 6.x reaches its end of life on `2019-04-30`

The main things we get by merging this are:
 * Native async/await support in build/server code
 * We no longer need `co`, since it was being used exclusively for async chains in tests
 * Compiled TS output (blueprints, tests) can be ES2017 instead of ES2016