### PR TITLE
Handle package/addon name mismatch

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Tests",
+      "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+      "args": [
+        "-r", "register-ts-node",
+        "-f", "generates .d.ts files when addon and package names do not match",
+        "ts/tests/**/*.{ts,js}"
+      ],
+      "internalConsoleOptions": "openOnSessionStart"
+    }
+  ]
+}

--- a/ts/lib/commands/precompile.ts
+++ b/ts/lib/commands/precompile.ts
@@ -36,6 +36,15 @@ export default command({
 
     let manifestPath = options.manifestPath;
     let packageName = this.project.pkg.name;
+
+    // Ensure that if we are dealing with an addon that is using a different
+    // addon name from its package name, we use the addon name, since that is
+    // how it will be written for imports.
+    let addon = this.project.addons.find(addon => addon.root === this.project.root);
+    if (addon && addon.name !== packageName) {
+      packageName = addon.name;
+    }
+
     let createdFiles = copyDeclarations(pathRoots, paths, packageName, this.project.root);
 
     fs.mkdirsSync(path.dirname(manifestPath));
@@ -66,5 +75,5 @@ export default command({
     ];
 
     return { rootDir, paths, pathRoots };
-  }
+  },
 });

--- a/ts/tests/commands/precompile-test.ts
+++ b/ts/tests/commands/precompile-test.ts
@@ -60,8 +60,8 @@ describe('Acceptance: ts:precompile command', function() {
     });
   });
 
-  describe('remapped addon-test-support', function() {
-    it('generates .d.ts files in the mapped location', function() {
+  describe('addon-test-support', function() {
+    it('generates .d.ts files in remapped locations', function() {
       fs.ensureDirSync('addon-test-support');
       fs.writeFileSync('addon-test-support/test-file.ts', `export const testString: string = 'hello';`);
 
@@ -78,5 +78,22 @@ describe('Acceptance: ts:precompile command', function() {
           expect(declaration.content.trim()).to.equal(`export declare const testString: string;`);
         });
     });
+  });
+
+  it('generates .d.ts files when addon and package names do not match', function() {
+    fs.ensureDirSync('addon-test-support');
+    fs.writeFileSync('addon-test-support/test-file.ts', `export const testString: string = 'hello';`);
+    fs.writeFileSync('index.js', `module.exports = { name: 'my-addon' };`);
+
+    const pkg = fs.readJSONSync('package.json');
+    pkg.name = '@foo/my-addon';  // addon `name` is `my-addon`
+    fs.writeJSONSync('package.json', pkg);
+
+    return ember(['ts:precompile'])
+      .then(() => {
+        const declaration = file('test-support/test-file.d.ts');
+        expect(declaration).to.exist;
+        expect(declaration.content.trim()).to.equal(`export declare const testString: string;`);
+      });
   });
 });


### PR DESCRIPTION
In 1.x, we [explicitly handled][old] renames of `addon-test-support` to `test-support`. In 944d3e36, however, that logic was removed in favor of some (generally much nicer) handling that *only* [deals with package names][new]. This works as expected, except when packages have a different name from the addon, i.e. `package.json`'s `name` field is different from the `name` field in the addon's `index.js`.

This change:

- adds a test for `addon-test-support` mapping when the addon's `name` field does not match the `package.json`'s `name` field.
- uses the addon's `name` field if it is both set and different from the `package.json`'s `name` field.

It builds on #667 – however, I'm seeing what *should* be (but may not be? It's confusing) unrelated failures locally, and that PR is also not passing.

---

<details><summary>original writeup with request for input, which @dfreeman nicely gave</summary>

There are a few things I'd love input on here:

1. I do not love the way I'm looking for the current addon, but I don't see any good way to do it with public API from Ember CLI other than this (and it's what the great and terrible rwjblue recommended in fact).
2. This test isn't actually working—I suspect an ordering issue. Manually inspecting the contents of the test files on disk, they look correct for the test, but the addon is never located by the logic in (1). It's possible that simply means that the logic in (1) is wrong, but if so it's not obvious to me *where*.
3. I *think* we should probably use a fixture for this scenario instead of patching the output of `ember new`. 😆 I'm up for better suggestions than that, too, though.

[old]: https://github.com/typed-ember/ember-cli-typescript/blob/v1.5.0/ts/lib/commands/precompile.js#L48:L53
[new]: https://github.com/typed-ember/ember-cli-typescript/blob/v2.0.0/ts/lib/utilities/copy-declarations.ts

</details>