### PR TITLE
Fix node tests when run locally with ts-node

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "start": "ember serve",
     "test": "yarn test:app && yarn test:node",
     "test:app": "ember test",
-    "test:node": "mocha -r register-ts-node ts/tests/**/*.{ts,js}",
+    "test:node": "mocha -r register-ts-node ts/tests/**/*.ts",
     "ci:prepare": "yarn prepublishOnly && rimraf ts",
     "ci:log-version-info": "echo '---- Ember CLI ----' && ember -v && echo '---- TypeScript ----' && tsc -v",
     "ci:test": "yarn ci:log-version-info && yarn ci:test:app && yarn ci:test:node",

--- a/register-ts-node.js
+++ b/register-ts-node.js
@@ -6,10 +6,11 @@ if (!require.extensions['.ts']) {
 
   // If we're operating in the context of another project, which might happen
   // if someone has installed ember-cli-typescript from git, only perform
-  // transpilation and skip the default ignore glob (which prevents anything
-  // in node_modules from being transpiled)
+  // transpilation. In this case, we also overwrite the default ignore glob
+  // (which ignores everything in `node_modules`) to instead ignore anything
+  // that doesn't end with `.ts`.
   if (process.cwd() !== __dirname) {
-    options.skipIgnore = true;
+    options.ignore = [/\.(?!ts$)\w+$/];
     options.transpileOnly = true;
   }
 


### PR DESCRIPTION
It turns out the issue that's been breaking `yarn test:node` in local development is [this line](https://github.com/emberjs/ember.js/blob/56d60eac537933e20ef66e735299b81dba9a1788/packages/loader/lib/index.js#L5), which relies on being in sloppy mode to create a global variable.

In development, our acceptance tests run in an environment that's comparable to what you'd get if you install `ember-cli-typescript` from git—[this arm](https://github.com/typed-ember/ember-cli-typescript/blob/067e15bc2a72f93d845f398b22882c425b7a2123/index.js#L11-L14) is hit when the addon loads, and so we automatically enable `ts-node` in (what's intended to be) a non-intrusive way. In fact, though, the fact that we're setting `skipIgnore: true` to enable processing TS files in `node_modules` has the side effect of causing _every_ file to get processed.

It's not totally clear to me whether this is a bug in `ts-node`, but it meant that `'use strict'` was being added at the top of the template transpiler module, so the global variable creation of `mainContext` became a type error.

It also massively slowed down a lot of our tests—with this change, our build acceptance tests go from taking 25-30 seconds apiece locally down to 6-8 seconds. (Note this wasn't an issue in CI, because we transpile everything ahead of time to ensure we're testing what would actually be in the published package, so `ts-node` never comes into play there.)