### PR TITLE
chore(pull request template): clarify commit format

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!-- Thanks for submitting a pull request! 🎉 -->
 
-<!-- Please note that commit messages need to follow the [commitlint](https://commitlint.js.org/#/) format.
+<!-- Please note that commit messages need to follow the [Conventional Commits](https://www.conventionalcommits.org) format.
 
 For example:
 test: fix node tests when run locally with ts-node


### PR DESCRIPTION
Just a small change to clarify the commit format.

(commitlint is the the tool that enforces the format, but documentation of the format itself lives at https://www.conventionalcommits.org)