### PR TITLE
(un)feat: remove MU support from the default blueprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
+### 💥 Breaking
+
+- Removes support in the default blueprint for initializing new Module Unification projects, in line with [MU's removal][MU] from Ember's roadmap in favor of other directions. Existing MU projects should continue to build and typecheck according to the local `tsconfig.json`. ([#826](https://github.com/typed-ember/ember-cli-typescript/pull/826))
+
+[MU]: https://blog.emberjs.com/2019/03/11/update-on-module-unification-and-octane.html
+
 ## [2.0.2] - 2019-07-05
 
 - Lock `@babel/plugin-transform-typescript` version pending a fix to [babel/babel#10162](https://github.com/babel/babel/issues/10162) ([#751](https://github.com/typed-ember/ember-cli-typescript/pull/751))

--- a/ts/tests/commands/precompile-test.ts
+++ b/ts/tests/commands/precompile-test.ts
@@ -38,8 +38,8 @@ describe('Acceptance: ts:precompile command', function() {
     expect(declaration).not.to.exist;
   });
 
-  describe('module unification', function() {
-    it('generates .d.ts files from the src tree', async () => {
+  describe('custom project layout', function() {
+    it('generates .d.ts files from the specified source tree', async () => {
       fs.ensureDirSync('src');
       fs.writeFileSync('src/test-file.ts', `export const testString: string = 'hello';`);
 

--- a/ts/types/ember-cli/index.d.ts
+++ b/ts/types/ember-cli/index.d.ts
@@ -95,6 +95,5 @@ declare module 'ember-cli/lib/models/project' {
     name(): string;
     isEmberCLIAddon(): boolean;
     require(module: string): unknown;
-    isModuleUnification(): boolean;
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,14 +8,27 @@
     "inlineSources": true,
     "baseUrl": ".",
     "paths": {
-      "dummy/tests/*": ["tests/*", "tests/dummy/lib/in-repo-a/test-support/*"],
-      "dummy/src/*": ["tests/dummy/src/*"],
-      "dummy/*": ["tests/dummy/app/*", "tests/dummy/lib/in-repo-a/app/*", "tests/dummy/lib/in-repo-b/app/*"],
-      "in-repo-a/*": ["tests/dummy/lib/in-repo-a/addon/*"],
-      "in-repo-a/test-support": ["tests/dummy/lib/in-repo-a/addon-test-support/"],
-      "in-repo-a/test-support/*": ["tests/dummy/lib/in-repo-a/addon-test-support/*"],
-      "in-repo-b/*": ["tests/dummy/lib/in-repo-b/addon/*"],
-      "in-repo-c/src/*": ["tests/dummy/lib/in-repo-c/src/*"]
+      "dummy/tests/*": [
+        "tests/*",
+        "tests/dummy/lib/in-repo-a/test-support/*"
+      ],
+      "dummy/*": [
+        "tests/dummy/app/*",
+        "tests/dummy/lib/in-repo-a/app/*",
+        "tests/dummy/lib/in-repo-b/app/*"
+      ],
+      "in-repo-a/*": [
+        "tests/dummy/lib/in-repo-a/addon/*"
+      ],
+      "in-repo-a/test-support": [
+        "tests/dummy/lib/in-repo-a/addon-test-support/"
+      ],
+      "in-repo-a/test-support/*": [
+        "tests/dummy/lib/in-repo-a/addon-test-support/*"
+      ],
+      "in-repo-b/*": [
+        "tests/dummy/lib/in-repo-b/addon/*"
+      ]
     }
   },
   "include": [


### PR DESCRIPTION
This PR implements the portion of https://github.com/typed-ember/ember-cli-typescript/issues/806 corresponding to `ember-cli-typescript` itself — the remainder of the change will be in the blueprints package.

We still support building/typechecking/generating `.d.ts` files for nonstandard project layouts, but the default blueprint will no longer support configuring new MU projects for TypeScript automatically.