### PR TITLE
fix: enable nullish coalescing and optional chaining unconditionally

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "testdouble": "3.12.4",
     "tmp": "0.1.0",
     "ts-node": "8.4.1",
-    "typescript": "3.6.4"
+    "typescript": "3.7.2"
   },
   "resolutions": {
     "@types/ember": "3.1.1",

--- a/tests/unit/build-test.ts
+++ b/tests/unit/build-test.ts
@@ -39,4 +39,13 @@ module('Unit | Build', function() {
     let instance = new TestClass('hello');
     assert.equal(instance.field, 'hello');
   });
+
+  // TODO: enable once a release of Prettier comes out that supports this syntax
+  // test('optional chaining and nullish coalescing are transpiled correctly', function(assert) {
+  //   let value = { a: 'hello' } as { a?: string; b?: string };
+  //   assert.equal(value?.a, 'hello');
+  //   assert.equal(value?.b, undefined);
+  //   assert.equal(value?.a ?? 'ok', 'hello');
+  //   assert.equal(value?.b ?? 'ok', 'ok');
+  // });
 });

--- a/ts/addon.ts
+++ b/ts/addon.ts
@@ -79,11 +79,10 @@ export default addon({
 
     // As of 3.7, TS supports the optional chaining and nullish coalescing proposals.
     // https://devblogs.microsoft.com/typescript/announcing-typescript-3-7-beta/
-    let tsVersion = this._getProjectTypeScriptVersion();
-    if (semver.gte(tsVersion, '3.7.0-alpha.0')) {
-      this._addBabelPluginIfNotPresent('@babel/plugin-proposal-optional-chaining');
-      this._addBabelPluginIfNotPresent('@babel/plugin-proposal-nullish-coalescing-operator');
-    }
+    // Since we can't necessarily know what version of TS an addon was developed with,
+    // we unconditionally add the Babel plugins for both proposals.
+    this._addBabelPluginIfNotPresent('@babel/plugin-proposal-optional-chaining');
+    this._addBabelPluginIfNotPresent('@babel/plugin-proposal-nullish-coalescing-operator');
 
     // Needs to come after the class properties plugin (see tests/unit/build-test.ts -
     // "property initialization occurs in the right order")
@@ -187,17 +186,6 @@ export default addon({
     let target = this._getConfigurationTarget();
     if (!hasPlugin(target, pluginName)) {
       addPlugin(target, pluginName, pluginOptions);
-    }
-  },
-
-  _getProjectTypeScriptVersion() {
-    try {
-      let pkg = this.project.require('typescript/package.json') as { version: string };
-      return pkg.version;
-    } catch {
-      throw new Error(
-        `[ember-cli-typescript] Unable to determine project TypeScript version; is it installed?`
-      );
     }
   },
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7572,7 +7572,6 @@ esdoc-ecmascript-proposal-plugin@^1.0.0:
 
 esdoc@pzuraq/esdoc#015a342:
   version "1.0.4"
-  uid "015a3426b2e53b2b0270a9c00133780db3f1d144"
   resolved "https://codeload.github.com/pzuraq/esdoc/tar.gz/015a3426b2e53b2b0270a9c00133780db3f1d144"
   dependencies:
     babel-generator "6.26.0"
@@ -9516,10 +9515,12 @@ imurmurhash@^0.1.4:
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
 
 "in-repo-a@link:tests/dummy/lib/in-repo-a":
-  version "1.0.0"
+  version "0.0.0"
+  uid ""
 
 "in-repo-b@link:tests/dummy/lib/in-repo-b":
-  version "1.0.0"
+  version "0.0.0"
+  uid ""
 
 include-path-searcher@^0.1.0:
   version "0.1.0"
@@ -15718,10 +15719,10 @@ typescript-memoize@^1.0.0-alpha.3:
   dependencies:
     core-js "2.4.1"
 
-typescript@3.6.4:
-  version "3.6.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.4.tgz#b18752bb3792bc1a0281335f7f6ebf1bbfc5b91d"
-  integrity sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==
+typescript@3.7.2:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.2.tgz#27e489b95fa5909445e9fef5ee48d81697ad18fb"
+  integrity sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==
 
 uc.micro@^1.0.0, uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
Since we can't know what version of TypeScript an addon was using in development, we need to enable optional chaining and nullish coalescing unconditionally rather than based on the root project TypeScript version.

This should be a safe change, as the Babel plugins don't introduce any extra bundle content or runtime overhead if they're unused. Now let's just see if we can get a green CI run 😬 