### PR TITLE
fix: ensure we register Babel plugins with their full path

### DIFF
--- a/ts/addon.ts
+++ b/ts/addon.ts
@@ -185,7 +185,7 @@ export default addon({
   _addBabelPluginIfNotPresent(pluginName: string, pluginOptions?: AddPluginOptions) {
     let target = this._getConfigurationTarget();
     if (!hasPlugin(target, pluginName)) {
-      addPlugin(target, pluginName, pluginOptions);
+      addPlugin(target, require.resolve(pluginName), pluginOptions);
     }
   },
 


### PR DESCRIPTION
Currently we're specifying just the name of the Babel plugins we register, which works as long as some version of those plugins gets hoisted and is available to `require` from the host application's perspective. This fails, though, if the hoisting doesn't happen, or if the package is linked, or other dependency shenanigans are in play.

This PR adds our plugins by their full path rather than just by name (the helpers we use already account for either of these formats, so nothing else should need to change).