### PR TITLE
Fix precompile step

### DIFF
--- a/ts/lib/commands/precompile.ts
+++ b/ts/lib/commands/precompile.ts
@@ -27,7 +27,7 @@ export default command({
 
     // prettier-ignore
     await execa('tsc', [
-      '--allowJs', 'false',
+      '--allowJs', 'true',
       '--noEmit', 'false',
       '--rootDir', rootDir || this.project.root,
       '--isolatedModules', 'false',


### PR DESCRIPTION
Without this change I get this error when attempting to publish.:
```
Command failed with exit code 2: yarn tsc --allowJs false --noEmit false --rootDir /home/lprestonsegoiii/Development/NullVoxPopuli/ember-contextual-services --isolatedModules false --declaration --declarationDir /tmp/e-c-ts-precompile-18769 --emitDeclarationOnly
```

Only after this change am I able to publish addons. 

:man_shrugging: 