### PR TITLE
[v4] allow ember-cli-babel to manage TS transpilation

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "in-repo-b": "link:tests/dummy/lib/in-repo-b",
     "loader.js": "4.7.0",
     "mocha": "6.2.2",
-    "prettier": "1.18.2",
+    "prettier": "1.19.1",
     "qunit-dom": "0.9.2",
     "testdouble": "3.12.4",
     "tmp": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -39,12 +39,8 @@
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s -u"
   },
   "dependencies": {
-    "@babel/plugin-proposal-nullish-coalescing-operator": "^7.4.4",
-    "@babel/plugin-proposal-optional-chaining": "^7.6.0",
-    "@babel/plugin-transform-typescript": "~7.7.0",
     "ansi-to-html": "^0.6.6",
     "debug": "^4.0.0",
-    "ember-cli-babel-plugin-helpers": "^1.0.0",
     "execa": "^3.0.0",
     "fs-extra": "^8.0.0",
     "resolve": "^1.5.0",
@@ -140,8 +136,7 @@
   "ember-addon": {
     "configPath": "tests/dummy/config",
     "before": [
-      "broccoli-watcher",
-      "ember-cli-babel"
+      "broccoli-watcher"
     ]
   },
   "husky": {

--- a/tests/unit/build-test.ts
+++ b/tests/unit/build-test.ts
@@ -28,24 +28,19 @@ module('Unit | Build', function() {
     assert.equal(fromTs, 'From test-support');
   });
 
-  test('property initialization occurs in the right order', function(assert) {
-    class TestClass {
-      // we shouldn't encourage folks to write code like this, but tsc ensures
-      // that constructor param fields are set before field initializers run
-      field = this.constructorParam;
-      constructor(private constructorParam: string) {}
-    }
-
-    let instance = new TestClass('hello');
-    assert.equal(instance.field, 'hello');
+  test('optional chaining and nullish coalescing are transpiled correctly', function(assert) {
+    let value = { a: 'hello' } as { a?: string; b?: string };
+    assert.equal(value?.a, 'hello');
+    assert.equal(value?.b, undefined);
+    assert.equal(value?.a ?? 'ok', 'hello');
+    assert.equal(value?.b ?? 'ok', 'ok');
   });
 
-  // TODO: enable once a release of Prettier comes out that supports this syntax
-  // test('optional chaining and nullish coalescing are transpiled correctly', function(assert) {
-  //   let value = { a: 'hello' } as { a?: string; b?: string };
-  //   assert.equal(value?.a, 'hello');
-  //   assert.equal(value?.b, undefined);
-  //   assert.equal(value?.a ?? 'ok', 'hello');
-  //   assert.equal(value?.b ?? 'ok', 'ok');
-  // });
+  test('class field declarations work', function(assert) {
+    class MyClass {
+      declare foo: string;
+    }
+
+    assert.notOk('foo' in new MyClass());
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -441,14 +441,6 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-json-strings" "^7.2.0"
 
-"@babel/plugin-proposal-nullish-coalescing-operator@^7.4.4":
-  version "7.4.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.4.4.tgz#41c360d59481d88e0ce3a3f837df10121a769b39"
-  integrity sha512-Amph7Epui1Dh/xxUxS2+K22/MUi6+6JVTvy3P58tja3B6yKTSjwwx0/d83rF7551D6PVSSoplQb8GCwqec7HRw==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.0.0"
-    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.2.0"
-
 "@babel/plugin-proposal-object-rest-spread@^7.3.4":
   version "7.3.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.3.4.tgz#47f73cf7f2a721aad5c0261205405c642e424654"
@@ -472,14 +464,6 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-optional-catch-binding" "^7.2.0"
-
-"@babel/plugin-proposal-optional-chaining@^7.6.0":
-  version "7.6.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.6.0.tgz#e9bf1f9b9ba10c77c033082da75f068389041af8"
-  integrity sha512-kj4gkZ6qUggkprRq3Uh5KP8XnE1MdIO0J7MhdDX8+rAbB6dJ2UrensGIS+0NPZAaaJ1Vr0PN6oLUgXMU1uMcSg==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.0.0"
-    "@babel/plugin-syntax-optional-chaining" "^7.2.0"
 
 "@babel/plugin-proposal-unicode-property-regex@^7.2.0":
   version "7.2.0"
@@ -526,13 +510,6 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-syntax-nullish-coalescing-operator@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.2.0.tgz#f75083dfd5ade73e783db729bbd87e7b9efb7624"
-  integrity sha512-lRCEaKE+LTxDQtgbYajI04ddt6WW0WJq57xqkAZ+s11h4YgfRHhVA/Y2VhfPzzFD4qeLHWg32DMp9HooY4Kqlg==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.0.0"
-
 "@babel/plugin-syntax-object-rest-spread@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz#3b7a3e733510c57e820b9142a6579ac8b0dfad2e"
@@ -544,13 +521,6 @@
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.2.0.tgz#a94013d6eda8908dfe6a477e7f9eda85656ecf5c"
   integrity sha512-bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.0.0"
-
-"@babel/plugin-syntax-optional-chaining@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.2.0.tgz#a59d6ae8c167e7608eaa443fda9fa8fa6bf21dff"
-  integrity sha512-HtGCtvp5Uq/jH/WNUPkK6b7rufnCPLLlDAFN7cmACoIjaOOiXxUt3SswU5loHqrhtqTsa/WoLQ1OQ1AGuZqaWA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
@@ -983,15 +953,6 @@
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.4.5.tgz#ab3351ba35307b79981993536c93ff8be050ba28"
   integrity sha512-RPB/YeGr4ZrFKNwfuQRlMf2lxoCUaU01MTw39/OFE/RiL8HDjtn68BwEPft1P7JN4akyEmjGWAMNldOV7o9V2g==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.0.0"
-    "@babel/plugin-syntax-typescript" "^7.2.0"
-
-"@babel/plugin-transform-typescript@~7.7.0":
-  version "7.7.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.7.0.tgz#182be03fa8bd2ffd0629791a1eaa4373b7589d38"
-  integrity sha512-y3KYbcfKe+8ziRXiGhhnGrVysDBo5+aJdB+x8sanM0K41cnmK7Q5vBlQLMbOnW/HPjLG9bg7dLgYDQZZG9T09g==
-  dependencies:
-    "@babel/helper-create-class-features-plugin" "^7.7.0"
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-typescript" "^7.2.0"
 
@@ -9747,10 +9708,12 @@ imurmurhash@^0.1.4:
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
 
 "in-repo-a@link:tests/dummy/lib/in-repo-a":
-  version "1.0.0"
+  version "0.0.0"
+  uid ""
 
 "in-repo-b@link:tests/dummy/lib/in-repo-b":
-  version "1.0.0"
+  version "0.0.0"
+  uid ""
 
 include-path-searcher@^0.1.0:
   version "0.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13358,10 +13358,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@1.18.2:
-  version "1.18.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
-  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
+prettier@1.19.1:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
+  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
 pretty-hrtime@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
Based on [a conversation with some typed-ember folks and @rwjblue](https://discordapp.com/channels/480462759797063690/484421406659182603/654770983319896064), our likely plan moving forward is to have `ember-cli-babel` be responsible for setting up any relevant TypeScript Babel plugin(s) using the presence of `ember-cli-typescript` as a trigger. The rough sequence of events I'm picturing:
 - a `4.0.0-alpha.1` release of this package that includes this PR to stop touching Babel config on this side
 - a release of `ember-cli-babel` that looks for `ember-cli-typescript >= 4.0.0-alpha` and sets up the appropriate plugins if it finds them
 - subsequent updates here to enforce that we're always installed alongside at least that ember-cli-babel version
 - ...
 - `ember-cli-typescript@4.0.0` 🎉 

Note that this PR is targeting the v4 branch, which we can use as a central point to cut alpha releases and land other changes we want to include in our next major release as we coordinate with ember-cli-babel on the rollout.