### PR TITLE
docs: fix reference to Service `mySession`

### DIFF
--- a/tests/dummy/app/templates/docs/ts-guide/using-ts-effectively.md
+++ b/tests/dummy/app/templates/docs/ts-guide/using-ts-effectively.md
@@ -166,7 +166,7 @@ export default class UserProfile extends Component {
   @service mySession!: MySession;
 
   login(email: string, password: string) {
-    this.session.login(email, password);
+    this.mySession.login(email, password);
   }
 }
 ```


### PR DESCRIPTION
The Service is injected in the Class through the key `mySession` but is referred to `session` in the `login()` method.