### PR TITLE
Use Volta for CI instead of setup-node action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v1
-      - name: Install Node
-        uses: actions/setup-node@v1
-        with:
-          node-version: '^10'
+      - name: Setup Volta
+        uses: rwjblue/setup-volta@v1
       # https://github.com/expo/expo-github-action/issues/20#issuecomment-541676895
       - name: Raise Watched File Limit
         run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
@@ -61,10 +59,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v1
-      - name: Install Node
-        uses: actions/setup-node@v1
-        with:
-          node-version: '^10'
+      - name: Setup Volta
+        uses: rwjblue/setup-volta@v1
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
       - name: Prepare CI Environment
@@ -81,10 +77,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v1
-      - name: Install Node
-        uses: actions/setup-node@v1
-        with:
-          node-version: '^10'
+      - name: Setup Volta
+        uses: rwjblue/setup-volta@v1
       - name: Raise Watched File Limit
         run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
       - name: Install Dependencies
@@ -110,10 +104,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v1
-      - name: Install Node
-        uses: actions/setup-node@v1
-        with:
-          node-version: '^10'
+      - name: Setup Volta
+        uses: rwjblue/setup-volta@v1
       - name: Raise Watched File Limit
         run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
       - name: Install Dependencies


### PR DESCRIPTION
This configures the CI workflow to use [Volta](https://volta.sh/) instead of the setup-node action.