### PR TITLE
fix(deps): downgrade dependency semver to v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "fs-extra": "^8.0.0",
     "resolve": "^1.5.0",
     "rsvp": "^4.8.1",
-    "semver": "^7.0.0",
+    "semver": "^6.3.0",
     "stagehand": "^1.0.0",
     "walk-sync": "^2.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -15298,11 +15298,6 @@ semver@^4.3.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-4.3.6.tgz#300bc6e0e86374f7ba61068b5b1ecd57fc6532da"
   integrity sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=
 
-semver@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
-  integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
-
 semver@~5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"


### PR DESCRIPTION
This reverts #1010

`semver@^7.0.0` requires `node >= 10` so downgrading for now (so we don't have a breaking change in a 3.x release).

This slipped though when we were still testing on node 8 because apparently npm and yarn have [different behavior](https://github.com/npm/node-semver/commit/d61f828e64260a0a097f26210f5500e91a621828#r36473304).

npm:
```
$ npm install ember-cli-typescript@typed-ember/ember-cli-typescript#master
npm WARN notsup Unsupported engine for semver@7.1.1: wanted: {"node":">=10"} (current: {"node":"8.17.0","npm":"6.13.4"})
npm WARN notsup Not compatible with your version of node/npm: semver@7.1.1
```

as of `semver@7.1.0`, it breaks for yarn as well:
```
$ yarn upgrade ember-cli-typescript@typed-ember/ember-cli-typescript#master
yarn upgrade v1.21.1
[1/5] 🔍  Validating package.json...
[2/5] 🔍  Resolving packages...
[3/5] 🚚  Fetching packages...
error semver@7.1.1: The engine "node" is incompatible with this module. Expected version ">=10". Got "8.17.0"
```