### PR TITLE
Use temp dir in project for precompile

### DIFF
--- a/ts/lib/commands/precompile.ts
+++ b/ts/lib/commands/precompile.ts
@@ -42,6 +42,7 @@ export default command({
         all: true,
       });
     } catch (e) {
+      fs.removeSync(outDir);
       console.error(`\n${e.all}\n`);
       throw e;
     }

--- a/ts/lib/commands/precompile.ts
+++ b/ts/lib/commands/precompile.ts
@@ -1,4 +1,3 @@
-import os from 'os';
 import execa from 'execa';
 import fs from 'fs-extra';
 import path from 'path';
@@ -16,7 +15,7 @@ export default command({
   availableOptions: [{ name: 'manifest-path', type: String, default: PRECOMPILE_MANIFEST }],
 
   async run(options: { manifestPath: string }) {
-    let outDir = `${os.tmpdir()}/e-c-ts-precompile-${process.pid}`;
+    let outDir = `${process.cwd()}/e-c-ts-precompile-${process.pid}`;
     let { paths, rootDir, pathRoots } = this._loadConfig(outDir);
     if (!paths) {
       this.ui.writeLine(

--- a/ts/lib/commands/precompile.ts
+++ b/ts/lib/commands/precompile.ts
@@ -61,7 +61,7 @@ export default command({
 
     fs.mkdirsSync(path.dirname(manifestPath));
     fs.writeFileSync(manifestPath, JSON.stringify(createdFiles.reverse()));
-    fs.remove(outDir);
+    fs.removeSync(outDir);
   },
 
   _loadConfig(outDir: string) {


### PR DESCRIPTION
This changes `ts:precompile` to use a temp dir within the project (under cwd) instead of a system temp file. This is to work around https://github.com/microsoft/TypeScript/issues/34749#issuecomment-549916145

It also makes sure the temp dir is removed after the command is run, even if an error is encountered.