### PR TITLE
fix(typecheck-worker): avoid false-positive `willTypecheck`s on Linux

### DIFF
--- a/ts/lib/typechecking/worker/index.ts
+++ b/ts/lib/typechecking/worker/index.ts
@@ -138,7 +138,7 @@ export default class TypecheckWorker {
   private patchCompilerHostMethods(
     host: WatchCompilerHostOfConfigFile<SemanticDiagnosticsBuilderProgram>
   ) {
-    let { watchFile, watchDirectory, createProgram, afterProgramCreate = () => {} } = host;
+    let { watchFile, watchDirectory, afterProgramCreate = () => {} } = host;
 
     // Intercept tsc's `watchFile` to also invoke `mayTypecheck()` when a watched file changes
     host.watchFile = (path, callback, pollingInterval?) => {
@@ -167,14 +167,11 @@ export default class TypecheckWorker {
       );
     };
 
-    // Intercept `createProgram` to invoke `willTypecheck` beforehand, as we know at this
-    // point that a new check is definitively happening.
-    host.createProgram = (...params) => {
-      this.willTypecheck();
-      return createProgram.apply(host, params);
-    };
-
+    // Intercept `afterProgramCreate` to confirm when a suspected typecheck is happening
+    // and schedule the new diagnostics to be emitted.
     host.afterProgramCreate = (program) => {
+      this.willTypecheck();
+
       // The `afterProgramCreate` callback will be invoked synchronously when we first call
       // `createWatchProgram`, meaning we can enter `didTypecheck` before we're fully set up
       // (e.g. before `compilerOptions` has been set). We use `nextTick` to ensure that

--- a/ts/tests/helpers/skeleton-app.ts
+++ b/ts/tests/helpers/skeleton-app.ts
@@ -16,7 +16,7 @@ const getEmberPort = (() => {
 export default class SkeletonApp {
   port = getEmberPort();
   watched: WatchedBuild | null = null;
-  cleanupTempDir = () => rimraf(this.root, (error) => console.error(error));
+  cleanupTempDir = () => rimraf(this.root, (error) => error && console.error(error));
   root = path.join(process.cwd(), `test-skeleton-app-${Math.random().toString(36).slice(2)}`);
 
   constructor() {


### PR DESCRIPTION
We've seen occasional timeouts in CI for our test that verifies we don't block builds for file changes that don't trigger a new typecheck. Interestingly, these timeouts have never occurred on Windows, and I've also never managed to reproduce them locally on my Mac, but they pretty reliably occur every 3-4 runs on Linux.

Digging in (by running the offending test in a loop in CI), it seems that the change to a `.hbs` file is occasionally causing TypeScript's `createProgram` to be called, but then subsequently short circuited as some other piece of machinery discovers that the change in question doesn't matter. This is a problem for us, as we treat `createProgram` as proof that a typecheck has started, and if `afterProgramCreate` is never subsequently called, then our worker just sits on a pending promise forever.

Fortunately for us, when `afterProgramCreate` _is_ called, it's called synchronously near the end of `createProgram`, so from the perspective of the outside world, it doesn't matter if we call `willTypecheck` in `createProgram` or `afterProgramCreate`: no events will be dispatched in between those two functions anyway.