### PR TITLE
chore(ci): fix commitlint action config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,11 @@ jobs:
       steps:
         - name: Checkout Code
           uses: actions/checkout@v2
+          # We need the `with` argument here so that force pushes (e.g. from
+          # Renovate rebasing) work correctly.
+          # https://github.com/wagoid/commitlint-github-action/tree/d6a383492a776126bbeba8c1d797ead4baedaaae#usage
+          with:
+            fetch-depth: 0
         - name: Commitlint
           uses: wagoid/commitlint-github-action@v2.1.1
 


### PR DESCRIPTION
Since updating the `checkout` action, any rebased commit has been failing. This is because with `@actions@v2`, [we need to set `fetch-depth`](https://github.com/wagoid/commitlint-github-action/tree/d6a383492a776126bbeba8c1d797ead4baedaaae#usage), because by default the checkout action [only fetches the latest commit](https://github.com/wagoid/commitlint-github-action/issues/21#issuecomment-570662592)—a reasonable move for clone performance, but one that breaks the commitmlint action.

Aside: we may want to revisit the value of commitlint for this repo, as it's extra hassle for users and we're not actually making use of Semantic Release at this point. cc. @dfreeman @jamescdavis 