### PR TITLE
docs: Fix typos in the Ember Routes docs

### DIFF
--- a/docs/ember/routes.md
+++ b/docs/ember/routes.md
@@ -2,7 +2,7 @@
 
 Working with Routes is in general just working normal TypeScript classes. Ember's types supply the definitions for the various lifecycle events available within route subclasses, which will provide autocomplete and type-checking along the way in general.
 
-However, there is one thing to watch out for: the types of the arguments passed to methods will _not_ autocomplete as you may expect. This is because in _general_ a subclass may override a superclass method as long as it calls its superclass's method correctly. This is very bad practice, but it is legal JavaScript! This is never a concern for lifecyclehooks in Ember, because they are called by the framework itself. However, TypeScript does not and cannot know that, so we have to provide the types directly.
+However, there is one thing to watch out for: the types of the arguments passed to methods will _not_ autocomplete as you may expect. This is because in _general_ a subclass may override a superclass method as long as it calls its superclass's method correctly. This is very bad practice, but it is legal JavaScript! This is never a concern for lifecycle hooks in Ember, because they are called by the framework itself. However, TypeScript does not and cannot know that, so we have to provide the types directly.
 
 Accordingly, and because the `Transition` type is not currently exported as a public type, you may find it convenient to define it using TypeScript's `ReturnType` utility type, which does exactly what it sounds like and gives us a local type which is the type returned by some function. The `RouterService.transitionTo` returns a `Transition`, so we can rely on that as stable public API to define `Transition` locally ourselves:
 
@@ -23,7 +23,7 @@ This inconsistency will be solved in the future. For now, this workaround gets t
 ```typescript
 import Route from '@ember/routing/route';
 
-type Resolved<T> = T extends Promise<infer U> : U : T;
+type Resolved<P> = P extends Promise<infer T> ? T : P;
 
 export type MyRouteModel = Resolved<ReturnType<MyRoute['model']>>;
 


### PR DESCRIPTION
Hello there! I noticed some typos in the Ember Routes docs. This PR will:

1. Add a space between "lifecycle" and "hooks".
2. Fix syntax error in `Resolved` type (and use the same type definition as shown in the cookbook for consistency).
