### PR TITLE
Fix qunit types... again

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@types/got": "9.6.11",
     "@types/mocha": "8.0.4",
     "@types/node": "14.14.8",
-    "@types/qunit": "2.9.6",
+    "@types/qunit": "2.11.1",
     "@types/resolve": "1.17.1",
     "@types/semver": "7.3.4",
     "@typescript-eslint/eslint-plugin": "4.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1580,10 +1580,10 @@
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.3.tgz#b755a0934564a200d3efdf88546ec93c369abd03"
   integrity sha512-7s9EQWupR1fTc2pSMtXRQ9w9gLOcrJn+h7HOXw4evxyvVqMi4f+q7d2tnFe3ng3SNHjtK+0EzGMGFUQX4/AQRA==
 
-"@types/qunit@*", "@types/qunit@2.9.6":
-  version "2.9.6"
-  resolved "https://registry.yarnpkg.com/@types/qunit/-/qunit-2.9.6.tgz#5d6ba092920edf9dc7377f5091e36eb448743a02"
-  integrity sha512-FfKb3sBW9sdjj8mPzAXtsKn53sOHpzi4PZj0H7P5G24VruwaOmvi0L2kJpuYARQjOKRl/YVlZQ6JWPnspWOkZA==
+"@types/qunit@*", "@types/qunit@2.11.1":
+  version "2.11.1"
+  resolved "https://registry.yarnpkg.com/@types/qunit/-/qunit-2.11.1.tgz#3496d430d2bb0fa4761f00a27511f46020c6b410"
+  integrity sha512-vcM5+9O8LZuu5DYseaV4J7ehkYrhkv+aMIuxnF/OqMYlVEdv+odpCH1/5OVztiqxbCqTpQKWuELkMvG7OPycUQ==
 
 "@types/range-parser@*":
   version "1.2.3"


### PR DESCRIPTION
This bumps `@types/qunit` and `yarn-deduplicate`s to resolve the failing floating dependency tests... again.