### PR TITLE
chore: update option `noEmitOnError` to `true`

### DIFF
--- a/blueprint-files/ember-cli-typescript/tsconfig.json
+++ b/blueprint-files/ember-cli-typescript/tsconfig.json
@@ -13,7 +13,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitReturns": true,
-    "noEmitOnError": false,
+    "noEmitOnError": true,
     "noEmit": true,
     "inlineSourceMap": true,
     "inlineSources": true,


### PR DESCRIPTION
Fix the value of the tsconfig option `noEmitOnError` to `true`, to be consistent with what is currently mentioned in the documentation.

Fix #1402 .