### PR TITLE
Blueprints: improve specificity of `locationType` in config

### DIFF
--- a/blueprint-files/ember-cli-typescript/__config_root__/config/environment.d.ts
+++ b/blueprint-files/ember-cli-typescript/__config_root__/config/environment.d.ts
@@ -8,7 +8,7 @@ declare const config: {
   environment: string;
   modulePrefix: string;
   podModulePrefix: string;
-  locationType: string;
+  locationType: 'history' | 'hash';
   rootURL: string;
   APP: Record<string, unknown>;
 };


### PR DESCRIPTION
The only legal types here are `'history'` and `'hash'`. Specify as much in the type we generate.