### PR TITLE
Add more specific `locationType` type to match new ember types

### DIFF
--- a/blueprint-files/ember-cli-typescript/__config_root__/config/environment.d.ts
+++ b/blueprint-files/ember-cli-typescript/__config_root__/config/environment.d.ts
@@ -8,7 +8,7 @@ declare const config: {
   environment: string;
   modulePrefix: string;
   podModulePrefix: string;
-  locationType: string;
+  locationType: 'history' | 'auto' | 'none' | 'hash';
   rootURL: string;
   APP: Record<string, unknown>;
 };


### PR DESCRIPTION
With the new ember 4 types (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/58060), the `locationType` expects a more specific type than "string".
