### PR TITLE
Ignore no-empty-interface in the default app index.d.ts

### DIFF
--- a/ts/blueprints/ember-cli-typescript/index.js
+++ b/ts/blueprints/ember-cli-typescript/index.js
@@ -6,7 +6,10 @@ const path = require('path');
 const APP_DECLARATIONS = `import Ember from 'ember';
 
 declare global {
-  interface Array<T> extends Ember.ArrayPrototypeExtensions<T> {} // eslint-disable-line @typescript-eslint/no-empty-interface
+  // Prevents ESLint from "fixing" this via its auto-fix to turn it into a type
+  // alias (e.g. after running any Ember CLI generator)
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  interface Array<T> extends Ember.ArrayPrototypeExtensions<T> {}
   // interface Function extends Ember.FunctionPrototypeExtensions {}
 }
 

--- a/ts/blueprints/ember-cli-typescript/index.js
+++ b/ts/blueprints/ember-cli-typescript/index.js
@@ -236,7 +236,7 @@ module.exports = {
     if (scripts[type] && scripts[type] !== script) {
       this.ui.writeWarnLine(
         `Found a pre-existing \`${type}\` script in your package.json. ` +
-        `By default, ember-cli-typescript expects to run \`${script}\` in this hook.`
+          `By default, ember-cli-typescript expects to run \`${script}\` in this hook.`
       );
       return;
     }

--- a/ts/blueprints/ember-cli-typescript/index.js
+++ b/ts/blueprints/ember-cli-typescript/index.js
@@ -6,7 +6,7 @@ const path = require('path');
 const APP_DECLARATIONS = `import Ember from 'ember';
 
 declare global {
-  interface Array<T> extends Ember.ArrayPrototypeExtensions<T> {}
+  interface Array<T> extends Ember.ArrayPrototypeExtensions<T> {} // eslint-disable-line @typescript-eslint/no-empty-interface
   // interface Function extends Ember.FunctionPrototypeExtensions {}
 }
 
@@ -233,7 +233,7 @@ module.exports = {
     if (scripts[type] && scripts[type] !== script) {
       this.ui.writeWarnLine(
         `Found a pre-existing \`${type}\` script in your package.json. ` +
-          `By default, ember-cli-typescript expects to run \`${script}\` in this hook.`
+        `By default, ember-cli-typescript expects to run \`${script}\` in this hook.`
       );
       return;
     }


### PR DESCRIPTION
As noted in:

https://discord.com/channels/480462759797063690/484421406659182603/917815976244953151

eslint will coerce the empty interface for `Array` in `types/__app_name__/index.d.ts` into a type for `Array`, which breaks things. The [`no-empty-interface` rule](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-empty-interface.md) should not be binned, and `index.d.ts` should not be added to `.eslintignore`.

The rule's role is to prevent subtyping without any changes, so if `Array` were to extend two types, that would be another solution, but I don't know if merging the Ember array with some pretend other type is a good idea.
