### PR TITLE
Encourage the use of type-only imports

### DIFF
--- a/docs/ember-data/models.md
+++ b/docs/ember-data/models.md
@@ -62,7 +62,11 @@ export default class User extends Model {
 
 Relationships between models in Ember Data rely on importing the related models, like `import User from './user';`. This, naturally, can cause a recursive loop, as `/app/models/post.ts` imports `User` from `/app/models/user.ts`, and `/app/models/user.ts` imports `Post` from `/app/models/post.ts`. Recursive importing triggers an [`import/no-cycle`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-cycle.md) error from eslint. 
 
-One should be certain to make use of [type-only imports](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html), available since TypeScript 3.8, and write `import type User from './user';`.
+To avoid these errors, use of [type-only imports](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html), available since TypeScript 3.8:
+
+```ts
+import type User from './user';
+```
 
 ### `@belongsTo`
 

--- a/docs/ember-data/models.md
+++ b/docs/ember-data/models.md
@@ -58,7 +58,13 @@ export default class User extends Model {
 }
 ```
 
-## `@belongsTo`
+## Relationships
+
+Relationships between models in Ember Data rely on importing the related models, like `import User from './user';`. This, naturally, can cause a recursive loop, as `/app/models/post.ts` imports `User` from `/app/models/user.ts`, and `/app/models/user.ts` imports `Post` from `/app/models/post.ts`. Recursive importing triggers an [`import/no-cycle`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-cycle.md) error from eslint. 
+
+One should be certain to make use of [type-only imports](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html), available since TypeScript 3.8, and write `import type User from './user';`.
+
+### `@belongsTo`
 
 The type returned by the `@hasMany` decorator depends on whether the relationship is `{ async: true }` \(which it is by default\).
 
@@ -70,8 +76,8 @@ So, for example, you might define a class like this:
 ```typescript
 import Model, { belongsTo } from '@ember-data/model';
 import DS from 'ember-data'; // NOTE: this is a workaround, see discussion below!
-import User from './user';
-import Site from './site';
+import type User from './user';
+import type Site from './site';
 
 export default class Post extends Model {
   @belongsTo('user')
@@ -89,7 +95,7 @@ These are _type_-safe to define as always present, that is to leave off the `?` 
 
 Note, however, that this type-safety is not a guarantee of there being no runtime error: you still need to uphold the contract for non-async relationships \(that is: loading the data first, or side-loading it with the request\) to avoid throwing an error!
 
-## `@hasMany`
+### `@hasMany`
 
 The type returned by the `@hasMany` decorator depends on whether the relationship is `{ async: true }` \(which it is by default\).
 
@@ -102,8 +108,8 @@ So, for example, you might define a class like this:
 import Model, { hasMany } from '@ember-data/model';
 import EmberArray from '@ember/array';
 import DS from 'ember-data'; // NOTE: this is a workaround, see discussion below!
-import Comment from './comment';
-import User from './user';
+import type Comment from './comment';
+import type User from './user';
 
 export default class Thread extends Model {
   @hasMany('comment')


### PR DESCRIPTION
When I first started setting up my models, I was getting `import/no-cycle` errors. I've now added some language to encourage the used of `import type` in the model files, and I've also changed the examples to indicate that usage.