### PR TITLE
docs: fix typos

### DIFF
--- a/docs/ember-data/models.md
+++ b/docs/ember-data/models.md
@@ -23,7 +23,7 @@ import Model, { attr } from '@ember-data/model';
 import CustomType from '../transforms/custom-transform';
 
 export default class User extends Model {
-  @attr('string')
+  @attr()
   declare name?:  string;
 
   @attr('number')
@@ -47,7 +47,7 @@ One way to make this safer is to supply a default value using the `defaultValue`
 import Model, { attr } from '@ember-data/model';
 
 export default class User extends Model {
-  @attr('string')
+  @attr()
   declare name?:  string;
 
   @attr('number', { defaultValue: 13 })

--- a/docs/ember-data/models.md
+++ b/docs/ember-data/models.md
@@ -11,9 +11,9 @@ The type returned by the `@attr` decorator is whatever [Transform](https://api.e
 * If you supply no argument to `@attr`, the value is passed through without transformation.
 * If you supply one of the built-in transforms, you will get back a corresponding type:
   * `@attr('string')` → `string`
-  * `@attr(number)` → `number`, 
+  * `@attr('number')` → `number`
   * `@attr('boolean')` → `boolean`
-  * `@attr'date')` → `Date`
+  * `@attr('date')` → `Date`
 * If you supply a custom transform, you will get back the type returned by your transform.
 
 So, for example, you might write a class like this:
@@ -23,8 +23,8 @@ import Model, { attr } from '@ember-data/model';
 import CustomType from '../transforms/custom-transform';
 
 export default class User extends Model {
-  @attr()
-  name?:  string;
+  @attr('string')
+  declare name?:  string;
 
   @attr('number')
   declare age: number;
@@ -47,7 +47,7 @@ One way to make this safer is to supply a default value using the `defaultValue`
 import Model, { attr } from '@ember-data/model';
 
 export default class User extends Model {
-  @attr()
+  @attr('string')
   declare name?:  string;
 
   @attr('number', { defaultValue: 13 })
@@ -62,7 +62,7 @@ export default class User extends Model {
 
 Relationships between models in Ember Data rely on importing the related models, like `import User from './user';`. This, naturally, can cause a recursive loop, as `/app/models/post.ts` imports `User` from `/app/models/user.ts`, and `/app/models/user.ts` imports `Post` from `/app/models/post.ts`. Recursive importing triggers an [`import/no-cycle`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-cycle.md) error from eslint. 
 
-To avoid these errors, use of [type-only imports](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html), available since TypeScript 3.8:
+To avoid these errors, use [type-only imports](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html), available since TypeScript 3.8:
 
 ```ts
 import type User from './user';


### PR DESCRIPTION
Currently in the docs, `@attr() declare name?` is typed as `string`, and no example of
`@attr('string')` is given. I'm not sure if showing in the documentation
that not passing a transform to `@attr()` should explicitly default to
string is the correct thing to do, but I definitely think we should
model the use of `@attr('string')` in the code examples.

<!--

Thanks for submitting a pull request! 🎉

Please include a link to a GitHub issue if one exists.

If you don't hear from a maintainer within a few days, please feel free to ping us here or in #e-typescript on Discord!

-->
