### PR TITLE
docs: fix spelling resolveable -> resolvable

### DIFF
--- a/blueprint-files/ember-cli-typescript/tsconfig.json
+++ b/blueprint-files/ember-cli-typescript/tsconfig.json
@@ -5,10 +5,10 @@
     "moduleResolution": "node",
 
     // Trying to check Ember apps and addons with `allowJs: true` is a recipe
-    // for many unresolveable type errors, because with *considerable* extra
+    // for many unresolvable type errors, because with *considerable* extra
     // configuration it ends up including many files which are *not* valid and
     // cannot be: they *appear* to be resolve-able to TS, but are in fact not in
-    // valid Node-resolveable locations and may not have TS-ready types. This
+    // valid Node-resolvable locations and may not have TS-ready types. This
     // will likely improve over time
     "allowJs": false,
 
@@ -62,7 +62,7 @@
     "inlineSources": true,
 
     // The combination of `baseUrl` with `paths` allows Ember's classic package
-    // layout, which is not resolveable with the Node resolution algorithm, to
+    // layout, which is not resolvable with the Node resolution algorithm, to
     // work with TypeScript.
     "baseUrl": ".",
     "paths": <%= pathsFor(dasherizedPackageName) %>


### PR DESCRIPTION
These links lead to pages that say:
"The word you've entered isn't in the dictionary."
https://www.merriam-webster.com/dictionary/unresolveable
https://www.merriam-webster.com/dictionary/resolveable

I guess we who are picky about types can also be sticklers about spelling, or maybe it's something like OCD about those "squiggles" in the IDE....