### PR TITLE
docs: update discord channel name, fix typos

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,6 @@ Thanks for submitting a pull request! 🎉
 
 Please include a link to a GitHub issue if one exists.
 
-If you don't hear from a maintainer within a few days, please feel free to ping us here or in #e-typescript on Discord!
+If you don't hear from a maintainer within a few days, please feel free to ping us here or in #topic-typescript on Discord!
 
 -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -534,7 +534,7 @@ We now use Babel 7's support for TypeScript to build apps and addons. Most of th
 
 * Addons can no longer use `.ts` in app, because an addon's `app` directory gets merged with and uses the *host's* (i.e. the other addon or app's) preprocessors, and we cannot guarantee the host has TS support. Note that in-repo-addons will continue to work for in-repo addons because of the app build works with the host's (i.e. the app's, not the addon's) preprocessors.
 
-* Apps need to use `.js` for overrides in app, since the different file extension means apps no long consistently "win" over addon versions (a limitation of how Babel + app merging interact) – note that this won’t be a problem with Module Unification apps
+* Apps need to use `.js` for overrides in app, since the different file extension means apps no longer consistently "win" over addon versions (a limitation of how Babel + app merging interact) – note that this won’t be a problem with Module Unification apps
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Since we now integrate in a more traditional way into Ember CLI's build pipeline
 
 - Addons can no longer use `.ts` in `app`, because an addon's `app` directory gets merged with and uses the *host's* (i.e. the other addon or app's) preprocessors, and we cannot guarantee the host has TS support. Note that `.ts` will continue to work for in-repo addons because the app build works with the host's (i.e. the app's, not the addon's) preprocessors.
 
-- Similarly, apps must use `.js` to override addon defaults in `app`, since the different file extension means apps no long consistently "win" over addon versions (a limitation of how Babel + app merging interact).
+- Similarly, apps must use `.js` to override addon defaults in `app`, since the different file extension means apps no longer consistently "win" over addon versions (a limitation of how Babel + app merging interact).
 
 ##### Account for TS → Babel issues
 
@@ -151,7 +151,7 @@ ember-cli-typescript v2 uses Babel to compile your code, and the TypeScript comp
 
 - `const enum` is not supported at all. You will need to replace all uses of `const enum` with simply `enum` or constants.
 
-- Using ES5 getters or settings with `this` type annotations is not supported through at least Babel 7.3. However, they should also be unnecessary with ES6 classes, so you can simply *remove* the `this` type annotation.
+- Using ES5 getters or setters with `this` type annotations is not supported through at least Babel 7.3. However, they should also be unnecessary with ES6 classes, so you can simply *remove* the `this` type annotation.
 
 - Trailing commas after rest function parameters (`function foo(...bar[],) {}`) are disallowed by the ECMAScript spec, so Babel also disallows them.
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ When seeking help, you should first consider what you need, and which aspect of 
 
 ### 💬 Getting Started
 
-We have a channel (**`#e-typescript`**) on the [Ember Community Discord server](https://discordapp.com/invite/zT3asNS) where you can ask about getting started, good resources for self-directed learning and more.
+We have a channel (**`#topic-typescript`**) on the [Ember Community Discord server](https://discordapp.com/invite/zT3asNS) where you can ask about getting started, good resources for self-directed learning and more.
 
 ### 📚 Issues With Ember Type Definitions
 

--- a/docs/ts/current-limitations.md
+++ b/docs/ts/current-limitations.md
@@ -6,7 +6,7 @@ While TS already works nicely for many things in Ember, there are a number of co
 
 You'll frequently see errors for imports which TypeScript doesn't know how to resolve. **These won't stop the build from working;** they just mean TypeScript doesn't know where to find those.
 
-Writing these missing type definitions is a great way to pitch in! Jump in `#e-typescript` on the [Ember Community Discord server](https://discord.gg/zT3asNS) and we'll be happy to help you.
+Writing these missing type definitions is a great way to pitch in! Jump in `#topic-typescript` on the [Ember Community Discord server](https://discord.gg/zT3asNS) and we'll be happy to help you.
 
 ## Templates
 

--- a/docs/upgrade-notes.md
+++ b/docs/upgrade-notes.md
@@ -93,7 +93,7 @@ If you choose to make the upgrade manually with yarn or npm, here are the steps 
 Since we now integrate in a more traditional way into Ember CLI's build pipeline, there are two changes required for addons using TypeScript.
 
 * Addons can no longer use `.ts` in `app`, because an addon's `app` directory gets merged with and uses the _host's_ \(i.e. the other addon or app's\) preprocessors, and we cannot guarantee the host has TS support. Note that `.ts` will continue to work for in-repo addons because the app build works with the host's \(i.e. the app's, not the addon's\) preprocessors.
-* Similarly, apps must use `.js` to override addon defaults in `app`, since the different file extension means apps no long consistently "win" over addon versions \(a limitation of how Babel + app merging interact\).
+* Similarly, apps must use `.js` to override addon defaults in `app`, since the different file extension means apps no longer consistently "win" over addon versions \(a limitation of how Babel + app merging interact\).
 
 ### Account for TS → Babel issues
 
@@ -144,7 +144,7 @@ Any place where a type annotation overrides a _getter_
      Notably, this is not a problem for Glimmer components, so migrating to Octane will also help!
 
 * `const enum` is not supported at all. You will need to replace all uses of `const enum` with simply `enum` or constants.
-* Using ES5 getters or settings with `this` type annotations is not supported through at least Babel 7.3. However, they should also be unnecessary with ES6 classes, so you can simply _remove_ the `this` type annotation.
+* Using ES5 getters or setters with `this` type annotations is not supported through at least Babel 7.3. However, they should also be unnecessary with ES6 classes, so you can simply _remove_ the `this` type annotation.
 * Trailing commas after rest function parameters \(`function foo(...bar[],) {}`\) are disallowed by the ECMAScript spec, so Babel also disallows them.
 * Re-exports of types have to be disambiguated to be _types_, rather than values. Neither of these will work:
 

--- a/known-typings.md
+++ b/known-typings.md
@@ -5,7 +5,7 @@ course find many other modules with their own typings out there.)
 
 Don't see an addon you use listed here? You might be the one to write them! Check
 out [this blog post] or [this quest issue] for tips on how to do it, and feel free
-to ask for help in the `#e-typescript` channel on the [Ember Community Discord server].
+to ask for help in the `#topic-typescript` channel on the [Ember Community Discord server].
 
 [this blog post]: http://www.chriskrycho.com/2017/typing-your-ember-part-5.html
 [this quest issue]: https://github.com/typed-ember/ember-typings/issues/14

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -81,7 +81,7 @@ for inclusion by ember-cli-typescript.
 * RFCs that are candidates for inclusion will enter a "final comment period"
 lasting 7 days. The beginning of this period will be signaled with a comment
 and tag on the RFC's pull request. Furthermore, the Typed Ember team will post
-in Discord in `#e-typescript` and `#news-and-announcements`.
+in Discord in `#topic-typescript` and `#news-and-announcements`.
 * An RFC can be modified based upon feedback from the Typed Ember team and
 the community. Significant modifications may trigger a new final comment period.
 * An RFC may be rejected by the team after public discussion has settled and


### PR DESCRIPTION
I updated the references to the old `#e-typescript` discord channel with the new `#topic-typescript`. Also a few minor spelling/typo fixes. 
Cheers!