### PR TITLE
Update blueprint to use `@tsconfig/ember`

### DIFF
--- a/blueprint-files/ember-cli-typescript/tsconfig.json
+++ b/blueprint-files/ember-cli-typescript/tsconfig.json
@@ -1,65 +1,6 @@
 {
+  "extends": "@tsconfig/ember/tsconfig.json",
   "compilerOptions": {
-    "target": "ES2021",
-    "module": "ES2020",
-    "moduleResolution": "node",
-
-    // Trying to check Ember apps and addons with `allowJs: true` is a recipe
-    // for many unresolvable type errors, because with *considerable* extra
-    // configuration it ends up including many files which are *not* valid and
-    // cannot be: they *appear* to be resolve-able to TS, but are in fact not in
-    // valid Node-resolvable locations and may not have TS-ready types. This
-    // will likely improve over time
-    "allowJs": false,
-
-    // --- TS for SemVer Types compatibility
-    // Strictness settings -- you should *not* change these: Ember code is not
-    // guaranteed to type check with these set to looser values.
-    "strict": true,
-    "noUncheckedIndexedAccess": true,
-
-    // Interop: these are viral and will require anyone downstream of your
-    // package to *also* set them to true. If you *must* enable them to consume
-    // an upstream package, you should document that for downstream consumers to
-    // be aware of.
-    //
-    // These *are* safe for apps to enable, since they do not *have* downstream
-    // consumers; but leaving them off is still preferred when possible, since
-    // it makes it easier to switch between apps and addons and have the same
-    // rules for what can be imported and how.
-    "allowSyntheticDefaultImports": false,
-    "esModuleInterop": false,
-
-    // --- Lint-style rules
-
-    // TypeScript also supplies some lint-style checks; nearly all of them are
-    // better handled by ESLint with the `@typescript-eslint`. This one is more
-    // like a safety check, though, so we leave it on.
-    "noPropertyAccessFromIndexSignature": true,
-
-    // --- Compilation/integration settings
-    // Setting `noEmitOnError` here allows ember-cli-typescript to catch errors
-    // and inject them into Ember CLI's build error reporting, which provides
-    // nice feedback for when
-    "noEmitOnError": true,
-
-    // We use Babel for emitting runtime code, because it's very important that
-    // we always and only use the same transpiler for non-stable features, in
-    // particular decorators. If you were to change this to `true`, it could
-    // lead to accidentally generating code with `tsc` instead of Babel, and
-    // could thereby result in broken code at runtime.
-    "noEmit": true,
-
-    // Ember makes heavy use of decorators; TS does not support them at all
-    // without this flag.
-    "experimentalDecorators": true,
-
-    // Support generation of source maps. Note: you must *also* enable source
-    // maps in your `ember-cli-babel` config and/or `babel.config.js`.
-    "declaration": true,
-    "declarationMap": true,
-    "inlineSourceMap": true,
-    "inlineSources": true,
 
     // The combination of `baseUrl` with `paths` allows Ember's classic package
     // layout, which is not resolvable with the Node resolution algorithm, to

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@ember/optional-features": "2.0.0",
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",
+    "@tsconfig/ember": "^1.0.0",
     "@typed-ember/renovate-config": "1.2.1",
     "@types/capture-console": "1.0.1",
     "@types/chai": "4.3.0",

--- a/ts/blueprints/ember-cli-typescript/index.js
+++ b/ts/blueprints/ember-cli-typescript/index.js
@@ -148,6 +148,7 @@ module.exports = {
 
     let packages = [
       'typescript',
+      '@tsconfig/ember',
       'ember-cli-typescript-blueprints',
       '@types/ember-resolver',
       '@types/ember__test-helpers',

--- a/ts/tests/blueprints/ember-cli-typescript-test.ts
+++ b/ts/tests/blueprints/ember-cli-typescript-test.ts
@@ -60,6 +60,7 @@ describe('Acceptance: ember-cli-typescript generator', function () {
     expect(pkgJson.scripts.postpack).to.be.undefined;
     expect(pkgJson.devDependencies).to.include.all.keys('ember-cli-typescript-blueprints');
     expect(pkgJson.devDependencies).to.include.all.keys('ember-data');
+    expect(pkgJson.devDependencies).to.include.all.keys('@tsconfig/ember');
     expect(pkgJson.devDependencies).to.include.all.keys('@types/ember-data');
     expect(pkgJson.devDependencies).to.include.all.keys('@types/ember-data__adapter');
     expect(pkgJson.devDependencies).to.include.all.keys('@types/ember-data__model');
@@ -73,14 +74,12 @@ describe('Acceptance: ember-cli-typescript generator', function () {
     expect(tsconfig).to.exist;
 
     const tsconfigJson = ts.parseConfigFileTextToJson('tsconfig.json', tsconfig.content).config;
+    expect(tsconfigJson.extends).to.equal('@tsconfig/ember/tsconfig.json');
     expect(tsconfigJson.compilerOptions.paths).to.deep.equal({
       'my-app/tests/*': ['tests/*'],
       'my-app/*': ['app/*'],
       '*': ['types/*'],
     });
-
-    expect(tsconfigJson.compilerOptions.inlineSourceMap).to.equal(true);
-    expect(tsconfigJson.compilerOptions.inlineSources).to.equal(true);
 
     expect(tsconfigJson.include).to.deep.equal(['app/**/*', 'tests/**/*', 'types/**/*']);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1099,6 +1099,11 @@
   dependencies:
     defer-to-connect "^2.0.0"
 
+"@tsconfig/ember@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@tsconfig/ember/-/ember-1.0.0.tgz#e982a5d47b03bb0ac5a93d011596f8520e046d96"
+  integrity sha512-2FXPaVQLJxDHzfkHYVH2R3YC62/e1/k3kQ/1KyzET8/MhJoJeL9F+wmPxASm8v2QYBj8Ct+COS+ZTknrfJ/SAQ==
+
 "@typed-ember/renovate-config@1.2.1":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@typed-ember/renovate-config/-/renovate-config-1.2.1.tgz#2e964c03a60df375a5a67aad9ef7d84911101a1c"
@@ -7415,9 +7420,11 @@ imurmurhash@^0.1.4:
 
 "in-repo-a@link:tests/dummy/lib/in-repo-a":
   version "0.0.0"
+  uid ""
 
 "in-repo-b@link:tests/dummy/lib/in-repo-b":
   version "0.0.0"
+  uid ""
 
 indent-string@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
This aligns us with the emerging default across the rest of the ecosystem and, just as importantly, means that we don't need to have folks do anything manually to stay in sync as we iterate on and improve the base config over time: they just need to upgrade the version of the base config they're using in their `package.json`.