### PR TITLE
Switch to `ember-cli-htmlbars`

### DIFF
--- a/docs/ember/testing.md
+++ b/docs/ember/testing.md
@@ -215,7 +215,7 @@ Now, with that setup out of the way, let’s get back to talking about the text 
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 import User from 'app/types/user';
 
@@ -283,7 +283,7 @@ Putting it all together, this is what our updated test definition would look lik
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, TestContext } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 import User from 'app/types/user';
 

--- a/docs/ts/current-limitations.md
+++ b/docs/ts/current-limitations.md
@@ -16,18 +16,18 @@ Addons need to import templates from the associated `.hbs` file to bind to the l
 
 ```ts
 declare module '\*/template' {
-  import { TemplateFactory } from 'htmlbars-inline-precompile';
+  import { TemplateFactory } from 'ember-cli-htmlbars';
   const template: TemplateFactory; export default template;
 }
 
 
 declare module 'app/templates/\*' {
-  import { TemplateFactory } from 'htmlbars-inline-precompile';
+  import { TemplateFactory } from 'ember-cli-htmlbars';
   const template: TemplateFactory; export default template;
 }
 
 declare module 'addon/templates/\*' {
-  import { TemplateFactory } from 'htmlbars-inline-precompile';
+  import { TemplateFactory } from 'ember-cli-htmlbars';
   const template: TemplateFactory; export default template;
 }
 ```
@@ -42,14 +42,14 @@ import { action } from '@ember/object';
 
 export default class MyGame extends Component {
   @action turnWheel(degrees: number) {
-    // ... 
+    // ...
   }
-} 
+}
 ```
 
 ```hbs
 <button {{on "click" (fn this.turnWheel "potato")}}>
-Click Me 
+Click Me
 </button>
 ```
 

--- a/tests/integration/components/js-importing-ts-test.js
+++ b/tests/integration/components/js-importing-ts-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | js importing ts', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/ts-component-test.js
+++ b/tests/integration/components/ts-component-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | ts component', function (hooks) {
   setupRenderingTest(hooks);

--- a/ts/blueprints/ember-cli-typescript/index.js
+++ b/ts/blueprints/ember-cli-typescript/index.js
@@ -22,7 +22,7 @@ export {};`;
 function buildTemplateDeclarations(projectName, layout) {
   const comment = '// Types for compiled templates';
   const moduleBody = `
-  import { TemplateFactory } from 'htmlbars-inline-precompile';
+  import { TemplateFactory } from 'ember-cli-htmlbars';
 
   const tmpl: TemplateFactory;
   export default tmpl;
@@ -171,7 +171,6 @@ module.exports = {
       '@types/ember__component',
       '@types/ember__routing',
       '@types/rsvp',
-      '@types/htmlbars-inline-precompile',
     ];
 
     if (this._has('@ember/jquery')) {

--- a/ts/tests/blueprints/ember-cli-typescript-test.ts
+++ b/ts/tests/blueprints/ember-cli-typescript-test.ts
@@ -148,7 +148,7 @@ describe('Acceptance: ember-cli-typescript generator', function () {
     const globalTypes = file('types/global.d.ts');
     expect(globalTypes).to.exist;
     expect(globalTypes).to.include("declare module 'my-addon/templates/*'").to.include(`
-  import { TemplateFactory } from 'htmlbars-inline-precompile';
+  import { TemplateFactory } from 'ember-cli-htmlbars';
 
   const tmpl: TemplateFactory;
   export default tmpl;


### PR DESCRIPTION
<!--

Thanks for submitting a pull request! 🎉

Please include a link to a GitHub issue if one exists.

If you don't hear from a maintainer within a few days, please feel free to ping us here or in #topic-typescript on Discord!

-->

Switch from deprecated package to replacement.

> [ember-cli-htmlbars-inline-precompile](https://github.com/ember-cli/ember-cli-htmlbars-inline-precompile)
> Deprecated
> Usage of this project is deprecated, its functionality has been migrated into [ember-cli-htmlbars](https://github.com/ember-cli/ember-cli-htmlbars) directly. Please upgrade to ember-cli-htmlbars@4.0.3 or higher.

Note: `@types/htmlbars-inline-precompile` is still present and I haven't touched that as I don't think there's a renamed/replacement package for its types (yet).