### PR TITLE
Fix `import/newline-after-import` lint violation in `global.d.ts`

### DIFF
--- a/ts/blueprints/ember-cli-typescript/index.js
+++ b/ts/blueprints/ember-cli-typescript/index.js
@@ -23,6 +23,7 @@ function buildTemplateDeclarations(projectName, layout) {
   const comment = '// Types for compiled templates';
   const moduleBody = `
   import { TemplateFactory } from 'htmlbars-inline-precompile';
+
   const tmpl: TemplateFactory;
   export default tmpl;
 `;

--- a/ts/tests/blueprints/ember-cli-typescript-test.ts
+++ b/ts/tests/blueprints/ember-cli-typescript-test.ts
@@ -149,6 +149,7 @@ describe('Acceptance: ember-cli-typescript generator', function () {
     expect(globalTypes).to.exist;
     expect(globalTypes).to.include("declare module 'my-addon/templates/*'").to.include(`
   import { TemplateFactory } from 'htmlbars-inline-precompile';
+
   const tmpl: TemplateFactory;
   export default tmpl;
 `);


### PR DESCRIPTION
<!--

Thanks for submitting a pull request! 🎉

Please include a link to a GitHub issue if one exists.

If you don't hear from a maintainer within a few days, please feel free to ping us here or in #topic-typescript on Discord!

-->

Fix lint violation from common ESLint lint rule [import/newline-after-import](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/newline-after-import.md).

```sh
yarn eslint --ext=.ts,.js .
~/Development/my-test-addon/types/global.d.ts
  3:3  error  Expected 1 empty line after import statement not followed by another import  import/newline-after-import
```