### PR TITLE
Fix `no-use-before-define` lint violation in `environment.d.ts`

### DIFF
--- a/blueprint-files/ember-cli-typescript/__config_root__/config/environment.d.ts
+++ b/blueprint-files/ember-cli-typescript/__config_root__/config/environment.d.ts
@@ -1,5 +1,3 @@
-export default config;
-
 /**
  * Type declarations for
  *    import config from 'my-app/config/environment'
@@ -12,3 +10,5 @@ declare const config: {
   rootURL: string;
   APP: Record<string, unknown>;
 };
+
+export default config;


### PR DESCRIPTION
<!--

Thanks for submitting a pull request! 🎉

Please include a link to a GitHub issue if one exists.

If you don't hear from a maintainer within a few days, please feel free to ping us here or in #topic-typescript on Discord!

-->

Running linting in a brand new Ember addon with TypeScript with the ESLint [no-use-before-define](https://eslint.org/docs/latest/rules/no-use-before-define) lint rule enabled:

```sh
~/Development/my-test-addon main * yarn eslint --ext=.ts,.js .

~/Development/my-test-addon/tests/dummy/app/config/environment.d.ts
  1:16  error  'config' was used before it was defined                                         no-use-before-define
```

This is an easy and harmless fix to avoid this lint violation for anyone using this lint rule. 

