### PR TITLE
Remove deprecated `@types/ember__test-helpers` from blueprint

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -26,7 +26,6 @@ We install all of the following packages at their current "latest" value, :
 * `@types/ember__*` – `@types/ember__object` for `@ember/object` etc.
 * `@types/ember-data__*` – `@types/ember-data__model` for `@ember-data/model` etc.
 * `@types/rsvp`
-* `@types/ember__test-helpers`
 
 ## Files this addon generates
 

--- a/ts/blueprints/ember-cli-typescript/index.js
+++ b/ts/blueprints/ember-cli-typescript/index.js
@@ -147,7 +147,6 @@ module.exports = {
       'typescript',
       'ember-cli-typescript-blueprints',
       '@types/ember-resolver',
-      '@types/ember__test-helpers',
       '@types/ember__object',
       '@types/ember__service',
       '@types/ember__controller',


### PR DESCRIPTION
The type package has been deprecated and is basically a no-op package, with types coming directly from `@ember/test-helpers`, so can be removed here.