### PR TITLE
Update getOwner example

### DIFF
--- a/docs/ember/services.md
+++ b/docs/ember/services.md
@@ -107,14 +107,14 @@ Services can also be loaded from the dependency injection container manually:
 
 ```typescript
 import Component from '@glimmer/component';
-import { getOwner } from '@ember/application';
+import { getOwner } from '@ember/owner';
 import { action } from '@ember/object';
 
 import ShoppingCartService from 'my-app/services/shopping-cart';
 
 export default class CartContentsComponent extends Component {
   get cart() {
-    return getOwner(this).lookup('service:shopping-cart') as ShoppingCartService;
+    return getOwner(this)?.lookup('service:shopping-cart') as ShoppingCartService;
   }
 
   @action


### PR DESCRIPTION
getOwner can now return undefined. This change updates the example code to better reflect the current types. See https://github.com/emberjs/ember.js/blob/d7b3f9d95a5bd2619c2762ffda6fbd0b57185cb4/packages/%40ember/-internals/owner/index.ts#L64-L69