### PR TITLE
docs: Reference Glint in docs

### DIFF
--- a/docs/ember/components.md
+++ b/docs/ember/components.md
@@ -4,7 +4,7 @@
 New to Ember or the Octane edition specifically? You may want to read [the Ember Guides’ material on `Component`s](https://guides.emberjs.com/release/components/) first!
 {% endhint %}
 
-Glimmer Components are defined in one of three ways: with templates only, with a template and a backing class, or with only a backing class \(i.e. a `yield`-only component\). When using a backing class, you get a first-class experience using TypeScript! Unfortunately, we don’t yet support type-checking for templates, but we hope to build that out eventually. Don’t let that stop you, though: types in your component classes make for a great experience, so let’s dig in and see how it works in practice.
+Glimmer Components are defined in one of three ways: with templates only, with a template and a backing class, or with only a backing class \(i.e. a `yield`-only component\). When using a backing class, you get a first-class experience using TypeScript! For type-checking Glimmer templates as well, see [Glint](https://typed-ember.gitbook.io/glint/).
 
 ## A simple component
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@ To get started, check out the instructions in [Getting Started: Installation](./
 * If you're totally new to using TypeScript with Ember, start with [TypeScript and Ember](./ts/README.md).
 * Once you have a good handle on the basics, you can dive into the guides to working with the APIs specific to [Ember](./ember/README.md) and [Ember Data](./ember-data/README.md).
 * If you're working with legacy (pre-Octane) Ember and TypeScript together, you should read [the Legacy Guide](./legacy/README.md).
+* Looking for type-checking in Glimmer templates? Check out [Glint](https://typed-ember.gitbook.io/glint/).
 
 ## Why TypeScript?
 


### PR DESCRIPTION
<!--

Thanks for submitting a pull request! 🎉

Please include a link to a GitHub issue if one exists.

If you don't hear from a maintainer within a few days, please feel free to ping us here or in #topic-typescript on Discord!

-->

This PR updates the docs to refer to Glint for template type checking.

For now the most obvious case has been adjusted, but a full review would be good to verify if there are more occurrences.