### PR TITLE
Remove `@types/ember-qunit` because `ember-qunit` provides its own ty…

### DIFF
--- a/ts/blueprints/ember-cli-typescript/index.js
+++ b/ts/blueprints/ember-cli-typescript/index.js
@@ -184,7 +184,6 @@ module.exports = {
     }
 
     if (this._has('ember-cli-qunit') || this._has('ember-qunit')) {
-      packages.push('@types/ember-qunit');
       packages.push('@types/qunit');
     }
 


### PR DESCRIPTION
…pes now.


Without this change, new projects using ember-cli-typescript have errors running `tsc`. See also, other work-arounds: https://github.com/embroider-build/addon-blueprint/pull/123

<!--

Thanks for submitting a pull request! 🎉

Please include a link to a GitHub issue if one exists.

If you don't hear from a maintainer within a few days, please feel free to ping us here or in #topic-typescript on Discord!

-->
