### PR TITLE
fix: typo in code example in components.md

### DIFF
--- a/docs/ember/components.md
+++ b/docs/ember/components.md
@@ -75,7 +75,7 @@ export interface ArgsDisplaySignature {
 }
 
 export default class ArgsDisplay extends Component<ArgsDisplaySignature> {
-  constructor(owner: unknown, args: ArgsDisplaySignature['Args]) {
+  constructor(owner: unknown, args: ArgsDisplaySignature['Args']) {
     super(owner, args);
 
     Object.keys(args).forEach(log);


### PR DESCRIPTION
Found a typo in the documentation. 
