### PR TITLE
Loosen version check against ember-cli-babel

### DIFF
--- a/ts/addon.ts
+++ b/ts/addon.ts
@@ -145,7 +145,7 @@ export default addon({
     let babel = this.parent.addons.find((addon) => addon.name === 'ember-cli-babel');
     let version = babel && babel.pkg.version;
 
-    if (!babel || !(semver.gte(version!, '7.17.0') && semver.lt(version!, '8.0.0'))) {
+    if (!babel || !semver.gte(version!, '7.17.0')) {
       let versionString = babel
         ? `version ${babel.pkg.version} installed`
         : `no instance of ember-cli-babel installed in your dependencies (check if it's in devDependencies instead?)`;


### PR DESCRIPTION
This gets us 'clean' support for interop with ember-cli-babel v8, which works just fine with this package.

Fixes #1567